### PR TITLE
Add option to control timeout

### DIFF
--- a/.github/workflows/update-docs.yaml
+++ b/.github/workflows/update-docs.yaml
@@ -33,6 +33,7 @@ jobs:
           any::rcmdcheck
           ropenspain/rostemplate
           dieghernan/pkgdev
+        needs: website
 
     - name: Install optipng
       run: |
@@ -63,7 +64,7 @@ jobs:
 
     - name: Update docs
       run: |
-        
+
         pkgdev::update_docs()
 
       shell: Rscript {0}

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ mapSpain*.tgz
 Meta
 CRAN-RELEASE
 cran-comments.md
-dev
 doc
 docs
 figure

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,20 +30,22 @@ Imports:
     giscoR (>= 1.0.0),
     httr2,
     jsonlite,
+    leaflet (>= 2.0.0),
     lifecycle,
     rappdirs (>= 0.3.0),
     sf (>= 1.0.0),
+    terra (>= 1.1-4),
+    testthat (>= 3.0.0),
     tibble,
+    tools,
     utils
 Suggests:
     dplyr,
     ggplot2 (>= 3.5.0),
     knitr,
-    leaflet (>= 2.0.0),
     quarto,
-    terra (>= 1.1-4),
-    testthat (>= 3.0.0),
-    tidyterra
+    tidyterra,
+    withr
 VignetteBuilder:
     quarto
 Config/Needs/check: curl

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,10 @@
 # mapSpain (development version)
 
-- Use `testthat::local_mocked_bindings()` on API error testing.
-- Migrate vignettes to Quarto.
+-   Use `testthat::local_mocked_bindings()` on API error testing.
+-   Migrate vignettes to Quarto.
+-   Query timeout can be controlled with `options(mapspain_timeout)` using
+    `httr2::req_timeout()`. Default value is
+    `httr2::req_timeout(..., seconds = 300)` (5 minutes).
 
 # mapSpain 1.0.0
 
@@ -28,208 +31,208 @@ versions.
 
 ## Breaking changes
 
-- Minimum required R version is now **4.1.0**.
-- Removed dependency on **slippymath** (#126).
-- `providerEspTileOptions()` has been removed; use
-  `leaflet::providerTileOptions()` instead.
-- Removed dataset `?esp_munic.sf`.
-- Removed dataset `?leaflet.providersESP.df` (superseded in mapSpain
-  **v0.8.0**).
-- Removed dataset `?pobmun19`; it has been replaced by `?pobmun25`.
-- `esp_get_grid_EEA()` is deprecated and defunct, as the source file is no
-  longer available.
+-   Minimum required R version is now **4.1.0**.
+-   Removed dependency on **slippymath** (#126).
+-   `providerEspTileOptions()` has been removed; use
+    `leaflet::providerTileOptions()` instead.
+-   Removed dataset `?esp_munic.sf`.
+-   Removed dataset `?leaflet.providersESP.df` (superseded in mapSpain
+    **v0.8.0**).
+-   Removed dataset `?pobmun19`; it has been replaced by `?pobmun25`.
+-   `esp_get_grid_EEA()` is deprecated and defunct, as the source file is no
+    longer available.
 
 ## Deprecations and new function names
 
-- `esp_getTiles()` has been renamed to `esp_get_tiles()` (old name still
-  works).
-- `esp_get_country()` has been renamed to `esp_get_spain()` (old name still
-  works).
-- In `esp_get_rivers()`:
-  - Arguments `resolution` and `spatialtype` are deprecated.
-  - Wetlands support has been moved to the new `esp_get_wetlands()`
-    function.
+-   `esp_getTiles()` has been renamed to `esp_get_tiles()` (old name still
+    works).
+-   `esp_get_country()` has been renamed to `esp_get_spain()` (old name still
+    works).
+-   In `esp_get_rivers()`:
+    -   Arguments `resolution` and `spatialtype` are deprecated.
+    -   Wetlands support has been moved to the new `esp_get_wetlands()`
+        function.
 
 ## New features
 
-- Added `esp_get_stations()`, replacing
-  `esp_get_railway(..., spatialtype = "point")`.
-- Added `esp_siane_bulk_download()` to download all SIANE datasets to a
-  specified `cache_dir` in a single step.
-- Added `esp_get_countries_siane()` to retrieve all countries available in
-  SIANE at a given date.
-- Added `esp_get_spain_siane()`, analogous to `esp_get_spain()`, using SIANE
-  data.
-- Added `esp_get_attributions()` to retrieve the attributions of a tile
-  provider.
-- Added dataset `?esp_nuts_2024`, replacing `?esp_nuts.sf`.
-- `esp_get_rivers()` gains a new `moveCAN` argument.
-- `esp_get_tiles()` can be used with providers that needs an API key.
+-   Added `esp_get_stations()`, replacing
+    `esp_get_railway(..., spatialtype = "point")`.
+-   Added `esp_siane_bulk_download()` to download all SIANE datasets to a
+    specified `cache_dir` in a single step.
+-   Added `esp_get_countries_siane()` to retrieve all countries available in
+    SIANE at a given date.
+-   Added `esp_get_spain_siane()`, analogous to `esp_get_spain()`, using SIANE
+    data.
+-   Added `esp_get_attributions()` to retrieve the attributions of a tile
+    provider.
+-   Added dataset `?esp_nuts_2024`, replacing `?esp_nuts.sf`.
+-   `esp_get_rivers()` gains a new `moveCAN` argument.
+-   `esp_get_tiles()` can be used with providers that needs an API key.
 
 # mapSpain 0.10.0
 
-- Fix a bug on `esp_get_prov_siane()` when selecting columns #115.
-- New argument `type` in `esp_get_comarca()`. Now it is possible to extract
-  different types of comarcas: Official (IGN), statistical (INE), agrarian or
-  livestock comarcas (MAPA).
+-   Fix a bug on `esp_get_prov_siane()` when selecting columns #115.
+-   New argument `type` in `esp_get_comarca()`. Now it is possible to extract
+    different types of comarcas: Official (IGN), statistical (INE), agrarian or
+    livestock comarcas (MAPA).
 
 # mapSpain 0.9.2
 
-- **SIANE 2024 Update**: Adapt functions to new databases.
-- Improve dictionaries: `esp_dict_region_code()` and `esp_dict_translate()`.
+-   **SIANE 2024 Update**: Adapt functions to new databases.
+-   Improve dictionaries: `esp_dict_region_code()` and `esp_dict_translate()`.
 
 # mapSpain 0.9.1
 
-- Update actions and docs.
+-   Update actions and docs.
 
 # mapSpain 0.9.0
 
-- Changes on how to handle modifications on Canary Islands objects (#101):
-  - Add a helper function for displace stand-alone `sf` objects in Canary
-    Islands: `esp_move_can()`.
-  - `esp_move_can()` is used internally on all functions.
-- Add a new function to show the current cache directory:
-  `esp_detect_cache_dir()`.
-- `mapSpain::layer_spatraster()` removed (was deprecated in **mapSpain**
-  0.6.2).
+-   Changes on how to handle modifications on Canary Islands objects (#101):
+    -   Add a helper function for displace stand-alone `sf` objects in Canary
+        Islands: `esp_move_can()`.
+    -   `esp_move_can()` is used internally on all functions.
+-   Add a new function to show the current cache directory:
+    `esp_detect_cache_dir()`.
+-   `mapSpain::layer_spatraster()` removed (was deprecated in **mapSpain**
+    0.6.2).
 
 # mapSpain 0.8.0
 
-- Improve download of NUTS data from **giscoR**.
-- Upgrade `?esp_tiles_providers` to
-  <https://dieghernan.github.io/leaflet-providersESP/> v1.3.3. New providers
-  included:
-  - `IDErioja.Base`
-  - `IDErioja.Relieve`
-  - `IDErioja.Claro`
-  - `IDErioja.Oscuro`
-- `esp_getTiles()` now supports non-OGC compliant WMTS providers, such as
-  Stamen or OpenStreetMaps (see examples).
+-   Improve download of NUTS data from **giscoR**.
+-   Upgrade `?esp_tiles_providers` to
+    <https://dieghernan.github.io/leaflet-providersESP/> v1.3.3. New providers
+    included:
+    -   `IDErioja.Base`
+    -   `IDErioja.Relieve`
+    -   `IDErioja.Claro`
+    -   `IDErioja.Oscuro`
+-   `esp_getTiles()` now supports non-OGC compliant WMTS providers, such as
+    Stamen or OpenStreetMaps (see examples).
 
 # mapSpain 0.7.0
 
-- Upgrade `?leaflet.providersESP.df` to
-  <https://dieghernan.github.io/leaflet-providersESP/> v1.3.2.
-- Changes on how to package manages tiles providers:
-  - `?leaflet.providersESP.df` is superseded in favor of
-    `?esp_tiles_providers`.
-  - You can use a custom url with the `type` argument in `esp_getTiles()`
-    (#88).
-  - Add new function `esp_make_provider()` that helps to create custom
-    providers.
+-   Upgrade `?leaflet.providersESP.df` to
+    <https://dieghernan.github.io/leaflet-providersESP/> v1.3.2.
+-   Changes on how to package manages tiles providers:
+    -   `?leaflet.providersESP.df` is superseded in favor of
+        `?esp_tiles_providers`.
+    -   You can use a custom url with the `type` argument in `esp_getTiles()`
+        (#88).
+    -   Add new function `esp_make_provider()` that helps to create custom
+        providers.
 
 # mapSpain 0.6.2
 
-- Now `moveCAN` is a explicit argument in the relevant functions.
-- Deprecate `layer_spatraster().` Use `tidyterra::geom_spatraster_rgb()`
-  instead.
-- Fix geometries on `esp_get_hex_prov()` and `esp_get_hex_ccaa()`.
-- Add new function to get comarcas from INE: `esp_get_comarca()`.
-- Add new functions to get simplified maps from INE:
-  - `esp_get_simpl_prov()`.
-  - `esp_get_simpl_ccaa()`.
+-   Now `moveCAN` is a explicit argument in the relevant functions.
+-   Deprecate `layer_spatraster().` Use `tidyterra::geom_spatraster_rgb()`
+    instead.
+-   Fix geometries on `esp_get_hex_prov()` and `esp_get_hex_ccaa()`.
+-   Add new function to get comarcas from INE: `esp_get_comarca()`.
+-   Add new functions to get simplified maps from INE:
+    -   `esp_get_simpl_prov()`.
+    -   `esp_get_simpl_ccaa()`.
 
 # mapSpain 0.6.1
 
-- HOTFIX: Bug on `esp_getTiles()` when `mask = TRUE`.
+-   HOTFIX: Bug on `esp_getTiles()` when `mask = TRUE`.
 
 # mapSpain 0.6.0
 
-- Upgrade `?leaflet.providersESP.df` to
-  <https://dieghernan.github.io/leaflet-providersESP/> v1.3.0. New providers:
-  - `Catastro.BuildingPart`
-  - `Catastro.AdministrativeBoundary`
-  - `Catastro.AdministrativeUnit`
-- Add new param `options` to `esp_getTiles()`.
-- Improve regex search on municipalities: Now the casing of the word is
-  ignored.
+-   Upgrade `?leaflet.providersESP.df` to
+    <https://dieghernan.github.io/leaflet-providersESP/> v1.3.0. New providers:
+    -   `Catastro.BuildingPart`
+    -   `Catastro.AdministrativeBoundary`
+    -   `Catastro.AdministrativeUnit`
+-   Add new param `options` to `esp_getTiles()`.
+-   Improve regex search on municipalities: Now the casing of the word is
+    ignored.
 
 # mapSpain 0.5.0
 
-- Rebuild coding database to avoid errors due to encoding.
-- Fix translations on Galician.
-- New grid functions (#61):
-  - `esp_get_grid_MTN()`
-  - `esp_get_grid_BDN()`
-  - `esp_get_grid_EEA()`
-  - `esp_get_grid_ESDAC()`
+-   Rebuild coding database to avoid errors due to encoding.
+-   Fix translations on Galician.
+-   New grid functions (#61):
+    -   `esp_get_grid_MTN()`
+    -   `esp_get_grid_BDN()`
+    -   `esp_get_grid_EEA()`
+    -   `esp_get_grid_ESDAC()`
 
 # mapSpain 0.4.0
 
-- Switch from **raster** to **terra**.
-- Clean up dependencies. Imagery packages moved to 'Suggests'.
-- Add `layer_spatraster()`.
-- Move examples to **ggplot2**.
+-   Switch from **raster** to **terra**.
+-   Clean up dependencies. Imagery packages moved to 'Suggests'.
+-   Add `layer_spatraster()`.
+-   Move examples to **ggplot2**.
 
 # mapSpain 0.3.1
 
-- Fix an error on **CRAN** related with the cache folder #52:
-  - Add `mapSpain::esp_clear_cache()`
-- Update docs with `@family` tag.
+-   Fix an error on **CRAN** related with the cache folder #52:
+    -   Add `mapSpain::esp_clear_cache()`
+-   Update docs with `@family` tag.
 
 # mapSpain 0.3.0
 
-- Caching improvements: new function `esp_set_cache_dir()` based on
-  `rappdirs::user_cache_dir()`. Now the cache_dir path is stored and it is not
-  necessary to set it up again on a new session.
-- Add a new argument `zoommin` on `esp_getTiles()`.
-- New tests with **testthat**.
-- Update on docs. New examples
-- Precompute vignette.
+-   Caching improvements: new function `esp_set_cache_dir()` based on
+    `rappdirs::user_cache_dir()`. Now the cache_dir path is stored and it is not
+    necessary to set it up again on a new session.
+-   Add a new argument `zoommin` on `esp_getTiles()`.
+-   New tests with **testthat**.
+-   Update on docs. New examples
+-   Precompute vignette.
 
 # mapSpain 0.2.3
 
-- Move minimum version of **giscoR** to v0.2.4
-- Fix typos on `esp_dict_translate()` (#36).
-- Not run examples on tiles, as the server sometimes doesn't respond.
-- Re factor `sysdata.rda`.
-- **CRAN** fixes:
-  - Removed broken link on `addProviderEspTiles()`.
-  - Vignette removed (**CRAN** warning).
-- Now the `cache` directory is created recursively.
+-   Move minimum version of **giscoR** to v0.2.4
+-   Fix typos on `esp_dict_translate()` (#36).
+-   Not run examples on tiles, as the server sometimes doesn't respond.
+-   Re factor `sysdata.rda`.
+-   **CRAN** fixes:
+    -   Removed broken link on `addProviderEspTiles()`.
+    -   Vignette removed (**CRAN** warning).
+-   Now the `cache` directory is created recursively.
 
 # mapSpain 0.2.2
 
-- Migrate examples, vignettes and README to **tmap**.
-- Add vignette to package.
-- `esp_dict_region_code()` works with mixed casings (e.g:
-  `esp_dict_region_code("aLbacEte", destination = "cpro")`).
+-   Migrate examples, vignettes and README to **tmap**.
+-   Add vignette to package.
+-   `esp_dict_region_code()` works with mixed casings (e.g:
+    `esp_dict_region_code("aLbacEte", destination = "cpro")`).
 
 # mapSpain 0.2.1
 
-- **QUICKFIX**: Fix a typo on documentation: `cache_dir` should be set as
-  `options(mapSpain_cache_dir = "path/to/dir")`.
+-   **QUICKFIX**: Fix a typo on documentation: `cache_dir` should be set as
+    `options(mapSpain_cache_dir = "path/to/dir")`.
 
 # mapSpain 0.2.0
 
-- Fix DOI <https://doi.org/10.5281/zenodo.4318024>
-- Documentation ported to **roxygen2**.
-- Include CartoBase ANE data
-  <https://github.com/rOpenSpain/mapSpain/tree/sianedata>:
-  - `mapSpain::esp_get_munic_siane()`
-  - `mapSpain::esp_get_prov_siane()`
-  - `mapSpain::esp_get_ccaa_siane()`
-  - `mapSpain::esp_get_hypsobath()`
-  - `mapSpain::esp_get_rivers()`
-  - `mapSpain::esp_get_hydrobasin()`
-  - `mapSpain::esp_get_capimun()`
-  - `mapSpain::esp_get_roads()`
-  - `mapSpain::esp_get_railway()`
-- Mute warnings from **rgdal**.
+-   Fix DOI <https://doi.org/10.5281/zenodo.4318024>
+-   Documentation ported to **roxygen2**.
+-   Include CartoBase ANE data
+    <https://github.com/rOpenSpain/mapSpain/tree/sianedata>:
+    -   `mapSpain::esp_get_munic_siane()`
+    -   `mapSpain::esp_get_prov_siane()`
+    -   `mapSpain::esp_get_ccaa_siane()`
+    -   `mapSpain::esp_get_hypsobath()`
+    -   `mapSpain::esp_get_rivers()`
+    -   `mapSpain::esp_get_hydrobasin()`
+    -   `mapSpain::esp_get_capimun()`
+    -   `mapSpain::esp_get_roads()`
+    -   `mapSpain::esp_get_railway()`
+-   Mute warnings from **rgdal**.
 
 # mapSpain 0.1.2
 
-- Fix annoying warning if **sf** was not loaded first.
-- Include new `poly` option on `mapSpain::esp_get_can_box()`.
-- New grids created with `geogrid::calculate_grid()`.
-- Add more years on `mapSpain::esp_get_munic()`.
-- Move to rOpenSpain organization.
+-   Fix annoying warning if **sf** was not loaded first.
+-   Include new `poly` option on `mapSpain::esp_get_can_box()`.
+-   New grids created with `geogrid::calculate_grid()`.
+-   Add more years on `mapSpain::esp_get_munic()`.
+-   Move to rOpenSpain organization.
 
 # mapSpain 0.1.1
 
-- Fix **CRAN** submission.
-- Added `mapSpain::esp_get_grid_prov()` and `mapSpain::esp_get_grid_ccaa()`.
+-   Fix **CRAN** submission.
+-   Added `mapSpain::esp_get_grid_prov()` and `mapSpain::esp_get_grid_ccaa()`.
 
 # mapSpain 0.1.0
 
-- Initial release.
+-   Initial release.

--- a/R/esp-check-access.R
+++ b/R/esp-check-access.R
@@ -22,6 +22,7 @@ esp_check_access <- function() {
   }
 
   req <- httr2::request("https://github.com/rOpenSpain/mapSpain/raw/sianedata/")
+  req <- httr2::req_timeout(req, getOption("mapspain_timeout", 300L))
   req <- httr2::req_url_path_append(req, "dist/se89_3_admin_ccaa_a_y.gpkg")
   req <- httr2::req_error(req, is_error = function(x) {
     FALSE

--- a/R/utils-url.R
+++ b/R/utils-url.R
@@ -47,6 +47,7 @@ download_url <- function(
   make_msg("info", verbose, msg)
 
   req <- httr2::request(url)
+  req <- httr2::req_timeout(req, getOption("mapspain_timeout", 300L))
   req <- httr2::req_error(req, is_error = function(x) {
     FALSE
   })
@@ -62,7 +63,6 @@ download_url <- function(
     max_age = 3600
   )
 
-  req <- httr2::req_timeout(req, 300)
   req <- httr2::req_retry(req, max_tries = 3)
   if (verbose) {
     req <- httr2::req_progress(req)

--- a/dev/config_attachment.yaml
+++ b/dev/config_attachment.yaml
@@ -1,0 +1,30 @@
+path.n: NAMESPACE
+path.d: DESCRIPTION
+dir.r: R
+dir.v: vignettes
+dir.t: tests
+extra.suggests: quarto
+pkg_ignore:
+  - devtools
+  - geobounds
+  - geodata
+  - geometries
+  - htmltools
+  - jsonify
+  - ragg
+  - rapidjsonr
+  - reactable
+  - remotes
+  - rmarkdown
+  - rnaturalearth
+  - ropensci/rnaturalearthhires
+  - ropenspain/rostemplate
+  - scales
+  - sessioninfo
+  - sfheaders
+  - tidyverse
+document: yes
+normalize: yes
+inside_rmd: no
+must.exist: yes
+check_if_suggests_is_installed: yes

--- a/tests/testthat/test-utils-url.R
+++ b/tests/testthat/test-utils-url.R
@@ -181,3 +181,33 @@ test_that("Test import jsonlite", {
   expect_silent(p <- for_import_jsonlite())
   expect_null(for_import_jsonlite())
 })
+
+test_that("Test timeout", {
+  skip_on_cran()
+  skip_if_siane_offline()
+
+  cdir <- file.path(tempdir(), "testthat_timeout")
+  if (dir.exists(cdir)) {
+    unlink(cdir, recursive = TRUE, force = TRUE)
+  }
+
+  url <- paste0(
+    "https://github.com/rOpenSpain/mapSpain/raw/sianedata/dist/",
+    "se89_3_admin_muni_a_x.gpkg"
+  )
+
+  withr::local_options(mapspain_timeout = 0.01)
+  expect_error(
+    download_url(url = url, verbose = FALSE, cache_dir = cdir),
+    "Failed to perform HTTP request(.*)Timeout(.*)after(.*)milliseconds"
+  )
+
+  withr::local_options(mapspain_timeout = 300L)
+  expect_silent(
+    ff <- download_url(url = url, verbose = FALSE, cache_dir = cdir)
+  )
+
+  expect_true(file.exists(ff))
+  unlink(cdir, recursive = TRUE, force = TRUE)
+  expect_false(file.exists(ff))
+})


### PR DESCRIPTION
Default timeout value is 300 seconds `getOption("mapspain_timeout", 300L)` , can be controlled with `options(mapspain_timeout)` (e.g. `options(mapspain_timeout = 0.01)` ~ 10 milliseconds).