### PR TITLE
Refactor internal helpers

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -16,8 +16,8 @@ identifiers:
 abstract: Administrative boundaries of Spain at several levels (Autonomous Communities,
   provinces and municipalities), based on 'GISCO' from 'Eurostat' <https://ec.europa.eu/eurostat/web/gisco>
   and 'CartoBase ANE' from 'Instituto Geográfico Nacional' <https://www.ign.es/>.
-  It also provides a plugin for 'leaflet' and tools to download and process static
-  map tiles.
+  It also provides a plugin for the 'leaflet' package and tools to download and process
+  static map tiles.
 authors:
 - family-names: Hernangómez
   given-names: Diego
@@ -38,8 +38,8 @@ preferred-citation:
   abstract: Administrative boundaries of Spain at several levels (Autonomous Communities,
     provinces and municipalities), based on GISCO from Eurostat <https://ec.europa.eu/eurostat/web/gisco>
     and CartoBase ANE from Instituto Geográfico Nacional <https://www.ign.es/>. It
-    also provides a plugin for leaflet and tools to download and process static map
-    tiles.
+    also provides a plugin for the leaflet package and tools to download and process
+    static map tiles.
 repository: https://CRAN.R-project.org/package=mapSpain
 repository-code: https://github.com/rOpenSpain/mapSpain
 url: https://ropenspain.github.io/mapSpain/

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,7 +8,7 @@ message: 'To cite package "mapSpain" in publications use:'
 type: software
 license: GPL-3.0-only
 title: 'mapSpain: Administrative Boundaries of Spain'
-version: 1.1.0
+version: 1.1.0.9000
 doi: 10.5281/zenodo.5366622
 identifiers:
 - type: doi
@@ -32,7 +32,7 @@ preferred-citation:
     email: diego.hernangomezherrero@gmail.com
     orcid: https://orcid.org/0000-0001-8457-4658
   year: '2026'
-  version: 1.1.0
+  version: 1.1.0.9000
   doi: 10.5281/zenodo.5366622
   url: https://ropenspain.github.io/mapSpain/
   abstract: Administrative boundaries of Spain at several levels (Autonomous Communities,
@@ -244,19 +244,6 @@ references:
   doi: 10.32614/CRAN.package.terra
   version: '>= 1.1-4'
 - type: software
-  title: testthat
-  abstract: 'testthat: Unit Testing for R'
-  notes: Imports
-  url: https://testthat.r-lib.org
-  repository: https://CRAN.R-project.org/package=testthat
-  authors:
-  - family-names: Wickham
-    given-names: Hadley
-    email: hadley@posit.co
-  year: '2026'
-  doi: 10.32614/CRAN.package.testthat
-  version: '>= 3.0.0'
-- type: software
   title: tibble
   abstract: 'tibble: Simple Data Frames'
   notes: Imports
@@ -395,12 +382,25 @@ references:
   year: '2026'
   doi: 10.32614/CRAN.package.quarto
 - type: software
+  title: testthat
+  abstract: 'testthat: Unit Testing for R'
+  notes: Suggests
+  url: https://testthat.r-lib.org
+  repository: https://CRAN.R-project.org/package=testthat
+  authors:
+  - family-names: Wickham
+    given-names: Hadley
+    email: hadley@posit.co
+  year: '2026'
+  doi: 10.32614/CRAN.package.testthat
+  version: '>= 3.0.0'
+- type: software
   title: tidyterra
   abstract: 'tidyterra: ''tidyverse'' Methods and ''ggplot2'' Helpers for ''terra''
     Objects'
   notes: Suggests
   url: https://dieghernan.github.io/tidyterra/
-  repository: https://CRAN.R-project.org/package=tidyterra
+  repository: https://dieghernan.r-universe.dev
   authors:
   - family-names: Hernangómez
     given-names: Diego

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: mapSpain
 Title: Administrative Boundaries of Spain
-Version: 1.1.0
+Version: 1.1.0.9000
 Authors@R: c(
     person("Diego", "Hernangómez", , "diego.hernangomezherrero@gmail.com", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0000-0001-8457-4658")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,6 @@ Imports:
     rappdirs (>= 0.3.0),
     sf (>= 1.0.0),
     terra (>= 1.1-4),
-    testthat (>= 3.0.0),
     tibble,
     tools,
     utils
@@ -44,6 +43,7 @@ Suggests:
     ggplot2 (>= 3.5.0),
     knitr,
     quarto,
+    testthat (>= 3.0.0),
     tidyterra,
     withr
 VignetteBuilder:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,8 +16,8 @@ Description: Administrative boundaries of Spain at several levels
     (Autonomous Communities, provinces and municipalities), based on
     'GISCO' from 'Eurostat' <https://ec.europa.eu/eurostat/web/gisco> and
     'CartoBase ANE' from 'Instituto Geográfico Nacional'
-    <https://www.ign.es/>. It also provides a plugin for 'leaflet' and
-    tools to download and process static map tiles.
+    <https://www.ign.es/>. It also provides a plugin for the 'leaflet'
+    package and tools to download and process static map tiles.
 License: GPL-3
 URL: https://ropenspain.github.io/mapSpain/,
     https://github.com/rOpenSpain/mapSpain

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,13 @@
   This is intended to simplify maintenance without changing the public API.
 - Consolidated repeated CCAA, province and municipality metadata handling
   across GISCO, SIANE, simplified and gridmap getters.
+- Further simplified internal cache handling, `sf` output finalization,
+  WMTS tile retrieval, dictionary translation and no-match messages. These
+  changes are intended to improve maintainability without changing user-facing
+  behavior.
+- Reviewed roxygen2 documentation, generated Rd files and prose documentation
+  for consistent terminology and clearer user-facing messages. This work was
+  completed with AI assistance and human review.
 - This internal refactor was developed with AI assistance and reviewed through
   focused package checks, including `devtools::load_all()` followed by
   `lintr::lint_package()`.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# mapSpain (development version)
+
 # mapSpain 1.1.0
 
 - Migrated package vignettes to Quarto.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,15 @@
 # mapSpain (development version)
 
+- Refactored internal helpers for downloading and reading geospatial files,
+  SIANE file handling, EPSG validation, region-code filtering, municipal
+  metadata enrichment, empty-result messages and Canary Islands displacement.
+  This is intended to simplify maintenance without changing the public API.
+- Consolidated repeated CCAA, province and municipality metadata handling
+  across GISCO, SIANE, simplified and gridmap getters.
+- This internal refactor was developed with AI assistance and reviewed through
+  focused package checks, including `devtools::load_all()` followed by
+  `lintr::lint_package()`.
+
 # mapSpain 1.1.0
 
 - Migrated package vignettes to Quarto.

--- a/R/addProviderEspTiles.R
+++ b/R/addProviderEspTiles.R
@@ -4,22 +4,22 @@ leaf_providers_esp_v <- "v1.3.3"
 #' Add a tile layer from Spanish public administrations to a \CRANpkg{leaflet}
 #' map
 #'
-#' @encoding UTF-8
+#' @param provider The name of the provider, see [esp_tiles_providers] or
+#'   <https://dieghernan.github.io/leaflet-providersESP/preview/>.
+#'
 #' @inheritParams leaflet::addProviderTiles
 #' @inherit leaflet::addProviderTiles return
-#' @family images
-#' @export
+#' @source
+#' <https://dieghernan.github.io/leaflet-providersESP/>, a plugin for
+#' \CRANpkg{leaflet}, **`r leaf_providers_esp_v`**.
 #'
 #' @seealso
 #' [leaflet::leaflet()], [leaflet::addTiles()], [leaflet::addWMSTiles()],
 #' [esp_tiles_providers].
 #'
-#' @source
-#' <https://dieghernan.github.io/leaflet-providersESP/>, a plugin for
-#' \CRANpkg{leaflet}, **`r leaf_providers_esp_v`**.
-#'
-#' @param provider The name of the provider, see [esp_tiles_providers] or
-#'   <https://dieghernan.github.io/leaflet-providersESP/preview/>.
+#' @family images
+#' @encoding UTF-8
+#' @export
 #'
 #' @examples
 #' library(leaflet)

--- a/R/data.R
+++ b/R/data.R
@@ -4,13 +4,64 @@
 #' A [tibble][tibble::tbl_df] object used internally for translating codes and
 #' names of the different subdivisions of Spain. This tibble provides a
 #' hierarchical representation of Spain's subdivisions, including NUTS1 level,
-#' Autonomous Communities (equivalent to NUTS2), provinces and NUTS3 level.
+#' Autonomous Communities (equivalent to NUTS2), provinces and NUTS3 levels.
 #' See the note below for coverage details.
 #'
-#' @docType data
-#' @encoding UTF-8
-#' @family datasets
-#' @name esp_codelist
+#' @format
+#' A [tibble][tibble::tbl_df] with `r nrow(mapSpain::esp_codelist)` rows and
+#' columns:
+#'
+#' \describe{
+#'  \item{nuts1.code}{NUTS 1 code.}
+#'  \item{nuts1.name}{NUTS 1 name.}
+#'  \item{nuts1.name.alt}{NUTS 1 alternative name.}
+#'  \item{nuts1.shortname.es}{NUTS 1 short (common) name (Spanish).}
+#'  \item{codauto}{INE code of the Autonomous Community.}
+#'  \item{iso2.ccaa.code}{ISO2 code of the Autonomous Community.}
+#'  \item{nuts2.code}{NUTS 2 code.}
+#'  \item{ine.ccaa.name}{INE name of the Autonomous Community.}
+#'  \item{iso2.ccaa.name.es}{ISO2 name of the Autonomous Community (Spanish).}
+#'  \item{iso2.ccaa.name.ca}{ISO2 name of the Autonomous Community (Catalan).}
+#'  \item{iso2.ccaa.name.gl}{ISO2 name of the Autonomous Community (Galician).}
+#'  \item{iso2.ccaa.name.eu}{ISO2 name of the Autonomous Community (Basque).}
+#'  \item{nuts2.name}{NUTS 2 name.}
+#'  \item{cldr.ccaa.name.en}{CLDR name of the Autonomous Community (English).}
+#'  \item{cldr.ccaa.name.es}{CLDR name of the Autonomous Community (Spanish).}
+#'  \item{cldr.ccaa.name.ca}{CLDR name of the Autonomous Community (Catalan).}
+#'  \item{cldr.ccaa.name.ga}{CLDR name of the Autonomous Community (Galician).}
+#'  \item{cldr.ccaa.name.eu}{CLDR name of the Autonomous Community (Basque).}
+#'  \item{ccaa.shortname.en}{Short (common) name of the Autonomous Community
+#'     (English).}
+#'  \item{ccaa.shortname.es}{Short (common) name of the Autonomous Community
+#'     (Spanish).}
+#'  \item{ccaa.shortname.ca}{Short (common) name of the Autonomous Community
+#'     (Catalan).}
+#'  \item{ccaa.shortname.ga}{Short (common) name of the Autonomous Community
+#'     (Galician).}
+#'  \item{ccaa.shortname.eu}{Short (common) name of the Autonomous Community
+#'     (Basque).}
+#'  \item{cpro}{INE code of the province.}
+#'  \item{iso2.prov.code}{ISO2 code of the province.}
+#'  \item{nuts.prov.code}{NUTS code of the province.}
+#'  \item{ine.prov.name}{INE name of the province.}
+#'  \item{iso2.prov.name.es}{ISO2 name of the province (Spanish).}
+#'  \item{iso2.prov.name.ca}{ISO2 name of the province (Catalan).}
+#'  \item{iso2.prov.name.ga}{ISO2 name of the province (Galician).}
+#'  \item{iso2.prov.name.eu}{ISO2 name of the province (Basque).}
+#'  \item{cldr.prov.name.en}{CLDR name of the province (English).}
+#'  \item{cldr.prov.name.es}{CLDR name of the province (Spanish).}
+#'  \item{cldr.prov.name.ca}{CLDR name of the province (Catalan).}
+#'  \item{cldr.prov.name.ga}{CLDR name of the province (Galician).}
+#'  \item{cldr.prov.name.eu}{CLDR name of the province (Basque).}
+#'  \item{prov.shortname.en}{Short (common) name of the province (English).}
+#'  \item{prov.shortname.es}{Short (common) name of the province (Spanish).}
+#'  \item{prov.shortname.ca}{Short (common) name of the province (Catalan).}
+#'  \item{prov.shortname.ga}{Short (common) name of the province (Galician).}
+#'  \item{prov.shortname.eu}{Short (common) name of the province (Basque).}
+#'  \item{nuts3.code}{NUTS 3 code.}
+#'  \item{nuts3.name}{NUTS 3 name.}
+#'  \item{nuts3.shortname.es}{NUTS 3 short (common) name.}
+#' }
 #'
 #' @source
 #' - **INE**: Instituto Nacional de Estadistica: <https://www.ine.es/>
@@ -19,71 +70,20 @@
 #' - **CLDR**:
 #'   <https://www.unicode.org/cldr/charts/48/subdivisionNames/index.html>
 #'
-#' @format
-#' A [tibble][tibble::tbl_df] with `r nrow(mapSpain::esp_codelist)` rows and
-#' columns:
-#'
-#' \describe{
-#'  \item{nuts1.code}{NUTS 1 code}
-#'  \item{nuts1.name}{NUTS 1 name}
-#'  \item{nuts1.name.alt}{NUTS 1 alternative name}
-#'  \item{nuts1.shortname.es}{NUTS 1 short (common) name (Spanish)}
-#'  \item{codauto}{INE code of the Autonomous Community}
-#'  \item{iso2.ccaa.code}{ISO2 code of the Autonomous Community}
-#'  \item{nuts2.code}{NUTS 2 code}
-#'  \item{ine.ccaa.name}{INE name of the Autonomous Community}
-#'  \item{iso2.ccaa.name.es}{ISO2 name of the Autonomous Community (Spanish)}
-#'  \item{iso2.ccaa.name.ca}{ISO2 name of the Autonomous Community (Catalan)}
-#'  \item{iso2.ccaa.name.gl}{ISO2 name of the Autonomous Community (Galician)}
-#'  \item{iso2.ccaa.name.eu}{ISO2 name of the Autonomous Community (Basque)}
-#'  \item{nuts2.name}{NUTS 2 name}
-#'  \item{cldr.ccaa.name.en}{CLDR name of the Autonomous Community (English)}
-#'  \item{cldr.ccaa.name.es}{CLDR name of the Autonomous Community (Spanish)}
-#'  \item{cldr.ccaa.name.ca}{CLDR name of the Autonomous Community (Catalan)}
-#'  \item{cldr.ccaa.name.ga}{CLDR name of the Autonomous Community (Galician)}
-#'  \item{cldr.ccaa.name.eu}{CLDR name of the Autonomous Community (Basque)}
-#'  \item{ccaa.shortname.en}{Short (common) name of the Autonomous Community
-#'     (English)}
-#'  \item{ccaa.shortname.es}{Short (common) name of the Autonomous Community
-#'     (Spanish)}
-#'  \item{ccaa.shortname.ca}{Short (common) name of the Autonomous Community
-#'     (Catalan)}
-#'  \item{ccaa.shortname.ga}{Short (common) name of the Autonomous Community
-#'     (Galician)}
-#'  \item{ccaa.shortname.eu}{Short (common) name of the Autonomous Community
-#'     (Basque)}
-#'  \item{cpro}{INE code of the province}
-#'  \item{iso2.prov.code}{ISO2 code of the province}
-#'  \item{nuts.prov.code}{NUTS code of the province}
-#'  \item{ine.prov.name}{INE name of the province}
-#'  \item{iso2.prov.name.es}{ISO2 name of the province (Spanish)}
-#'  \item{iso2.prov.name.ca}{ISO2 name of the province (Catalan)}
-#'  \item{iso2.prov.name.ga}{ISO2 name of the province (Galician)}
-#'  \item{iso2.prov.name.eu}{ISO2 name of the province (Basque)}
-#'  \item{cldr.prov.name.en}{CLDR name of the province (English)}
-#'  \item{cldr.prov.name.es}{CLDR name of the province (Spanish)}
-#'  \item{cldr.prov.name.ca}{CLDR name of the province (Catalan)}
-#'  \item{cldr.prov.name.ga}{CLDR name of the province (Galician)}
-#'  \item{cldr.prov.name.eu}{CLDR name of the province (Basque)}
-#'  \item{prov.shortname.en}{Short (common) name of the province (English)}
-#'  \item{prov.shortname.es}{Short (common) name of the province (Spanish)}
-#'  \item{prov.shortname.ca}{Short (common) name of the province (Catalan)}
-#'  \item{prov.shortname.ga}{Short (common) name of the province (Galician)}
-#'  \item{prov.shortname.eu}{Short (common) name of the province (Basque)}
-#'  \item{nuts3.code}{NUTS 3 code}
-#'  \item{nuts3.name}{NUTS 3 name}
-#'  \item{nuts3.shortname.es}{NUTS 3 short (common) name}
-#' }
-#'
 #' @note
 #' Although NUTS2 aligns with the first subdivision level of Spain
-#' (Autonomous Communities, CCAA), NUTS3 does not correspond to the second
+#' (Autonomous Communities), NUTS3 does not correspond to the second
 #' subdivision level of Spain (provinces). NUTS3
 #' provides dedicated codes for major islands, whereas provinces do not.
 #'
 #' Ceuta and Melilla have a special status as Autonomous Cities but are
 #' treated as Autonomous Communities with a single province (like Madrid,
 #' Asturias or Murcia) in this database.
+#'
+#' @family datasets
+#' @encoding UTF-8
+#' @docType data
+#' @name esp_codelist
 #'
 #' @examples
 #'
@@ -92,11 +92,6 @@
 NULL
 
 #' Population of Spain by municipality (2025)
-#'
-#' @docType data
-#' @encoding UTF-8
-#' @family datasets
-#' @name pobmun25
 #'
 #' @format
 #' A [tibble][tibble::tbl_df] object with
@@ -124,16 +119,16 @@ NULL
 #'
 #' ```
 #'
+#' @family datasets
+#' @encoding UTF-8
+#' @docType data
+#' @name pobmun25
+#'
 #' @examples
 #' data("pobmun25")
 NULL
 
 #' Public WMS and WMTS providers for Spain
-#'
-#' @docType data
-#' @encoding UTF-8
-#' @family datasets
-#' @name esp_tiles_providers
 #'
 #' @description
 #' A named [`list`][base::list] of length `r length(esp_tiles_providers)`
@@ -143,21 +138,6 @@ NULL
 #' Implementation of the JavaScript plugin
 #' [leaflet-providersESP](https://dieghernan.github.io/leaflet-providersESP/)
 #' **`r leaf_providers_esp_v`**.
-#'
-#' @source
-#' <https://dieghernan.github.io/leaflet-providersESP/>, a plugin for
-#' \CRANpkg{leaflet},
-#' **`r leaf_providers_esp_v`**.
-#'
-#' @format
-#' A named [`list`][base::list] of available providers with the following
-#' structure:
-#'
-#' - Each list item is named with the provider alias.
-#' - Each element contains two nested named lists:
-#'   - `static` with the parameters required to obtain static map tiles, plus an
-#'     additional item named `attribution`.
-#'   - `leaflet` with additional parameters to pass to [addProviderEspTiles()].
 #'
 #' @details
 #' Providers available to be passed to `type` in [esp_get_tiles()] are:
@@ -170,6 +150,26 @@ NULL
 #' cat(t)
 #'
 #' ```
+#' @format
+#' A named [`list`][base::list] of available providers with the following
+#' structure:
+#'
+#' - Each list item is named with the provider alias.
+#' - Each element contains two nested named lists:
+#'   - `static` with the parameters required to obtain static map tiles, plus an
+#'     additional item named `attribution`.
+#'   - `leaflet` with additional parameters to pass to [addProviderEspTiles()].
+#'
+#' @source
+#' <https://dieghernan.github.io/leaflet-providersESP/>, a plugin for
+#' \CRANpkg{leaflet},
+#' **`r leaf_providers_esp_v`**.
+#'
+#' @family datasets
+#' @encoding UTF-8
+#' @docType data
+#' @name esp_tiles_providers
+#'
 #' @examples
 #' data("esp_tiles_providers")
 #' # Get a single provider
@@ -183,18 +183,12 @@ NULL
 
 #' NUTS 2024 for Spain [`sf`][sf::st_sf] object
 #'
-#' @docType data
-#' @encoding UTF-8
-#' @family datasets
-#' @name esp_nuts_2024
-#'
-#' @seealso [esp_get_nuts()]
-#' @inherit giscoR::gisco_nuts_2024 details
-#'
 #' @description
 #' This dataset represents Spanish regions at NUTS levels 0, 1, 2 and 3
 #' according to the Nomenclature of Territorial Units for Statistics (NUTS)
 #' classification for 2024.
+#'
+#' @inherit giscoR::gisco_nuts_2024 details
 #'
 #' @format
 #' An [`sf`][sf::st_sf] object with `MULTIPOLYGON` geometries at 1:1 million
@@ -202,10 +196,10 @@ NULL
 #' `r nrow(mapSpain::esp_nuts_2024)` rows and 10 variables:
 #' \describe{
 #'   \item{`NUTS_ID`}{NUTS identifier.}
-#'   \item{`LEVL_CODE`}{NUTS level code `(0,1,2,3)`.}
+#'   \item{`LEVL_CODE`}{NUTS level code `(0, 1, 2, 3)`.}
 #'   \item{`CNTR_CODE`}{Eurostat country code.}
-#'   \item{`NAME_LATN`}{NUTS name on Latin characters.}
-#'   \item{`NUTS_NAME`}{NUTS name on local alphabet.}
+#'   \item{`NAME_LATN`}{NUTS name in Latin characters.}
+#'   \item{`NUTS_NAME`}{NUTS name in the local alphabet.}
 #'   \item{`MOUNT_TYPE`}{Mountain type, see **Details**.}
 #'   \item{`URBN_TYPE`}{Urban type, see **Details**.}
 #'   \item{`COAST_TYPE`}{Coastal type, see **Details**.}
@@ -223,6 +217,12 @@ NULL
 #'       "nuts/gpkg/) file."))
 #'
 #' ```
+#'
+#' @seealso [esp_get_nuts()]
+#' @family datasets
+#' @encoding UTF-8
+#' @docType data
+#' @name esp_nuts_2024
 #'
 #' @examples
 #' data("esp_nuts_2024")

--- a/R/esp-cache.R
+++ b/R/esp-cache.R
@@ -1,24 +1,9 @@
 #' Set your \CRANpkg{mapSpain} cache directory
 #'
-#' @encoding UTF-8
-#' @family cache utilities
-#' @seealso [tools::R_user_dir()]
-#'
-#' @rdname esp_set_cache_dir
-#'
 #' @description
 #' This function stores your `cache_dir` path on your local machine and loads
 #' it for future sessions. Use `Sys.getenv("MAPSPAIN_CACHE_DIR")` or
 #' [esp_detect_cache_dir()] to find the cached path.
-#'
-#' @inheritParams esp_get_nuts
-#' @param cache_dir A path to a cache directory. When `NULL`, the function
-#'   stores cached files in a temporary directory (see [base::tempdir()]).
-#' @param install Logical. If `TRUE`, installs the key on your local machine for
-#'   use in future sessions. Defaults to `FALSE`. If `cache_dir` is `FALSE`,
-#'   this argument is automatically set to `FALSE`.
-#' @param overwrite Logical. If `TRUE`, overwrites an existing
-#'   `MAPSPAIN_CACHE_DIR` on your local machine.
 #'
 #' @details
 #' By default, when no `cache_dir` is set, the package uses a folder inside
@@ -26,10 +11,6 @@
 #' ends). To persist a cache across \R sessions, use
 #' `esp_set_cache_dir(cache_dir, install = TRUE)`, which writes the chosen
 #' path to a configuration file under `tools::R_user_dir("mapSpain", "config")`.
-#'
-#' @return
-#' `esp_set_cache_dir()` returns an invisible character string with the path
-#' to your `cache_dir`. It is primarily called for its side effect.
 #'
 #' @section Caching strategies:
 #'
@@ -54,6 +35,19 @@
 #' method and save it to your `cache_dir`. Use `verbose = TRUE` to debug the
 #' API query and [esp_detect_cache_dir()] to identify your cache path.
 #'
+#' @param cache_dir A path to a cache directory. When `NULL`, the function
+#'   stores cached files in a temporary directory (see [base::tempdir()]).
+#' @param install Logical. If `TRUE`, installs the key on your local machine for
+#'   use in future sessions. Defaults to `FALSE`. If `cache_dir` is `FALSE`,
+#'   this argument is automatically set to `FALSE`.
+#' @param overwrite Logical. If `TRUE`, overwrites an existing
+#'   `MAPSPAIN_CACHE_DIR` on your local machine.
+#'
+#' @inheritParams esp_get_nuts
+#' @return
+#' `esp_set_cache_dir()` returns an invisible character string with the path
+#' to your `cache_dir`. It is primarily called for its side effect.
+#'
 #' @note
 #' In \CRANpkg{mapSpain} >= 1.0.0, the configuration file location has
 #' moved from `rappdirs::user_config_dir("mapSpain", "R")` to
@@ -61,6 +55,13 @@
 #' transfers previous configuration files from the old to the new location.
 #' A message appears once during this migration.
 #'
+#' @seealso [tools::R_user_dir()]
+#'
+#' @family cache utilities
+#' @encoding UTF-8
+#' @rdname esp_set_cache_dir
+#'
+#' @export
 #' @examples
 #'
 #' # Do not run this. It would modify your current state.
@@ -78,7 +79,6 @@
 #' identical(my_cache, esp_detect_cache_dir())
 #' }
 #'
-#' @export
 esp_set_cache_dir <- function(
   cache_dir = NULL,
   overwrite = FALSE,
@@ -128,12 +128,12 @@ esp_set_cache_dir <- function(
   invisible(cache_dir)
 }
 
-#' @export
-#' @rdname esp_set_cache_dir
 #' @return
 #' `esp_detect_cache_dir()` returns the path to the `cache_dir` used in the
 #' current session.
 #'
+#' @rdname esp_set_cache_dir
+#' @export
 #' @examples
 #'
 #' esp_detect_cache_dir()
@@ -146,12 +146,6 @@ esp_detect_cache_dir <- function() {
 
 #' Clear your \CRANpkg{mapSpain} cache directory
 #'
-#' @rdname esp_clear_cache
-#' @family cache utilities
-#' @encoding UTF-8
-#'
-#' @return Invisible. This function is called for its side effects.
-#'
 #' @description
 #' **Use this function with caution.** It clears your cached data and
 #' configuration, specifically:
@@ -161,18 +155,25 @@ esp_detect_cache_dir <- function() {
 #' - Deletes the `cache_dir` directory and its contents.
 #' - Clears the value stored in `Sys.getenv("MAPSPAIN_CACHE_DIR")`.
 #'
+#' @details
+#' This is an aggressive function intended to reset your installation as if you
+#' had never installed or used \CRANpkg{mapSpain}.
+#'
 #' @param config Logical. If `TRUE`, deletes the configuration folder of
 #'   \CRANpkg{mapSpain}.
 #' @param cached_data Logical. If `TRUE`, deletes your `cache_dir` and all
 #'   its contents.
 #' @inheritParams esp_set_cache_dir
 #'
+#' @return Invisible. This function is called for its side effects.
+#'
 #' @seealso [tools::R_user_dir()]
 #'
-#' @details
-#' This is an aggressive function intended to reset your installation as if you
-#' had never installed or used \CRANpkg{mapSpain}.
+#' @family cache utilities
+#' @encoding UTF-8
 #'
+#' @rdname esp_clear_cache
+#' @export
 #' @examples
 #'
 #' # Do not run this. It would modify your current state.
@@ -189,7 +190,6 @@ esp_detect_cache_dir <- function() {
 #' esp_set_cache_dir(my_cache)
 #' identical(my_cache, esp_detect_cache_dir())
 #' }
-#' @export
 esp_clear_cache <- function(
   config = FALSE,
   cached_data = TRUE,

--- a/R/esp-cache.R
+++ b/R/esp-cache.R
@@ -113,23 +113,7 @@ esp_set_cache_dir <- function(
   # nocov start
 
   if (install) {
-    config_dir <- tools::R_user_dir("mapSpain", "config")
-    # Create the cache configuration directory if needed.
-    if (!dir.exists(config_dir)) {
-      dir.create(config_dir, recursive = TRUE)
-    }
-
-    mapspain_file <- file.path(config_dir, "mapSpain_cache_dir")
-
-    if (!file.exists(mapspain_file) || overwrite) {
-      # Create file if it does not exist.
-      writeLines(cache_dir, con = mapspain_file)
-    } else {
-      cli::cli_abort(c(
-        "A {.arg cache_dir} path already exists.",
-        "You can overwrite it with {.arg overwrite = TRUE}."
-      ))
-    }
+    write_installed_cache_dir(cache_dir, overwrite)
     # nocov end
   } else {
     make_msg(
@@ -213,7 +197,7 @@ esp_clear_cache <- function(
 ) {
   migrate_cache()
 
-  config_dir <- tools::R_user_dir("mapSpain", "config")
+  config_dir <- cache_config_dir()
   data_dir <- detect_cache_dir_muted()
 
   # nocov start
@@ -226,16 +210,15 @@ esp_clear_cache <- function(
   }
   # nocov end
   if (cached_data && dir.exists(data_dir)) {
-    siz <- file.size(list.files(data_dir, recursive = TRUE, full.names = TRUE))
-    siz <- sum(siz, na.rm = TRUE)
-    class(siz) <- class(object.size("a"))
-
-    siz <- format(siz, unit = "auto")
+    siz <- cache_dir_size(data_dir)
     unlink(data_dir, recursive = TRUE, force = TRUE)
     if (verbose) {
-      cli::cli_alert_success(
-        "{.pkg mapSpain} data deleted: {.file {data_dir}} ({siz})."
+      msg <- paste0(
+        "{.pkg mapSpain} data deleted: {.file {data_dir}} (",
+        siz,
+        ")."
       )
+      cli::cli_alert_success(msg)
     }
   }
 
@@ -259,35 +242,62 @@ detect_cache_dir_muted <- function() {
   getvar <- ensure_null(getvar)
 
   if (is.null(getvar)) {
-    # If not set, try to retrieve the cached path.
-    cache_config <- file.path(
-      tools::R_user_dir("mapSpain", "config"),
-      "mapSpain_cache_dir"
-    )
+    cached_path <- read_installed_cache_dir()
 
-    # nocov start
-    if (file.exists(cache_config)) {
-      cached_path <- readLines(cache_config)
-      cached_path <- ensure_null(cached_path)
-
-      # Default when the cached path is empty.
-      if (is.null(cached_path)) {
-        cache_dir <- esp_set_cache_dir(overwrite = TRUE, verbose = FALSE)
-        return(cache_dir)
-      }
-
-      # Return the cached path.
-      Sys.setenv(MAPSPAIN_CACHE_DIR = cached_path)
-      cached_path
-      # nocov end
-    } else {
-      # Use the default cache location.
-      cache_dir <- esp_set_cache_dir(overwrite = TRUE, verbose = FALSE)
-      cache_dir
+    if (is.null(cached_path)) {
+      return(esp_set_cache_dir(overwrite = TRUE, verbose = FALSE))
     }
+
+    Sys.setenv(MAPSPAIN_CACHE_DIR = cached_path)
+    cached_path
   } else {
     getvar
   }
+}
+
+cache_config_dir <- function() {
+  tools::R_user_dir("mapSpain", "config")
+}
+
+cache_config_file <- function() {
+  file.path(cache_config_dir(), "mapSpain_cache_dir")
+}
+
+read_installed_cache_dir <- function() {
+  cache_config <- cache_config_file()
+  if (!file.exists(cache_config)) {
+    return(NULL)
+  }
+
+  ensure_null(readLines(cache_config))
+}
+
+write_installed_cache_dir <- function(cache_dir, overwrite = FALSE) {
+  config_dir <- cache_config_dir()
+  if (!dir.exists(config_dir)) {
+    dir.create(config_dir, recursive = TRUE)
+  }
+
+  mapspain_file <- cache_config_file()
+  if (!file.exists(mapspain_file) || overwrite) {
+    writeLines(cache_dir, con = mapspain_file)
+    return(invisible(cache_dir))
+  }
+
+  # nocov start
+  cli::cli_abort(c(
+    "A {.arg cache_dir} path already exists.",
+    "You can overwrite it with {.arg overwrite = TRUE}."
+  ))
+  # nocov end
+}
+
+cache_dir_size <- function(data_dir) {
+  siz <- file.size(list.files(data_dir, recursive = TRUE, full.names = TRUE))
+  siz <- sum(siz, na.rm = TRUE)
+  class(siz) <- class(object.size("a"))
+
+  format(siz, unit = "auto")
 }
 
 #' Create `cache_dir` if needed
@@ -325,10 +335,8 @@ migrate_cache <- function(
   old = rappdirs::user_config_dir("mapSpain", "R"),
   new = tools::R_user_dir("mapSpain", "config")
 ) {
-  fname <- "mapSpain_cache_dir"
-
-  old_fname <- file.path(old, fname)
-  new_fname <- file.path(new, fname)
+  old_fname <- file.path(old, basename(cache_config_file()))
+  new_fname <- file.path(new, basename(cache_config_file()))
 
   if (file.exists(new_fname)) {
     unlink(old, force = TRUE, recursive = TRUE)

--- a/R/esp-check-access.R
+++ b/R/esp-check-access.R
@@ -1,7 +1,5 @@
 #' Check access to SIANE data resources
 #'
-#' @encoding UTF-8
-#' @keywords internal
 #' @description
 #' Check whether \R has access to resources at
 #' <https://github.com/rOpenSpain/mapSpain/tree/sianedata>.
@@ -10,10 +8,12 @@
 #'
 #' @seealso [giscoR::gisco_check_access()].
 #'
+#' @keywords internal
+#' @encoding UTF-8
+#' @export
 #' @examples
 #'
 #' esp_check_access()
-#' @export
 esp_check_access <- function() {
   if (!httr2::is_online()) {
     return(FALSE) # nocov

--- a/R/esp-check-access.R
+++ b/R/esp-check-access.R
@@ -37,52 +37,6 @@ esp_check_access <- function() {
   }
 }
 
-#' Skip tests if SIANE data is not reachable
-#'
-#' @return Invisible. `TRUE` if offline logic passes or the test is skipped.
-#'
-#' @noRd
-skip_if_siane_offline <- function() {
-  # nocov start
-  test_offline <- is_404()
-  if (test_offline) {
-    return(invisible(TRUE))
-  }
-
-  if (esp_check_access()) {
-    return(invisible(TRUE))
-  }
-
-  if (requireNamespace("testthat", quietly = TRUE)) {
-    testthat::skip("SIANE API not reachable")
-  }
-  invisible()
-  # nocov end
-}
-
-#' Skip tests if GISCO API is not reachable
-#'
-#' @return Invisible. `TRUE` if offline logic passes or the test is skipped.
-#'
-#' @noRd
-skip_if_gisco_offline <- function() {
-  # nocov start
-  test_offline <- is_404()
-  if (test_offline) {
-    return(invisible(TRUE))
-  }
-
-  if (giscoR::gisco_check_access()) {
-    return(invisible(TRUE))
-  }
-
-  if (requireNamespace("testthat", quietly = TRUE)) {
-    testthat::skip("GISCO API not reachable")
-  }
-  invisible()
-  # nocov end
-}
-
 #' Internal function to check if we are on CRAN
 #' @return Logical scalar, `TRUE` if running on CRAN and `FALSE` otherwise.
 #' @noRd

--- a/R/esp-dict.R
+++ b/R/esp-dict.R
@@ -214,10 +214,7 @@ sanitize_region_code_output <- function(
   out[out %in% c("XXXXX", "YYYYY")] <- "NOMATCH"
 
   if (length(out[out != "NOMATCH"]) != length(sourcevar)) {
-    cli::cli_alert_warning(paste0(
-      "No match on {.arg destination = {.str {destination}}} found ",
-      "for {.str {initsourcevar[out == 'NOMATCH']}}."
-    ))
+    warn_no_match(initsourcevar[out == "NOMATCH"], destination)
   }
   out[out == "NOMATCH"] <- NA
 
@@ -264,55 +261,55 @@ esp_dict_translate <- function(sourcevar, lang = "en", all = FALSE) {
   avlang <- c("es", "en", "ca", "ga", "eu")
   lang <- match_arg_pretty(lang, avlang)
 
-  # Create dict
+  dict <- prepare_translation_dict()
+  tokeys <- translate_source_to_keys(sourcevar, dict)
+
+  if (any(tokeys == "NOMATCH")) {
+    warn_no_match(sourcevar[tokeys == "NOMATCH"])
+  }
+
+  dict_tolang <- translation_lang_dict(dict, lang)
+  namestrans <- translate_keys_to_lang(tokeys, dict_tolang, all)
+
+  format_translation_output(namestrans, sourcevar, all)
+}
+
+prepare_translation_dict <- function() {
   dict <- names_full
-
-  # Arrange priority for results:
-  # - First: prov (a_prov)
-  # - Second: ccaa (b_ccaa)
-  # - Last: nuts (c_nuts)
-
-  # Upgrade provs
   dict$variable <- gsub("prov", "a_prov", dict$variable, fixed = TRUE)
-  # Upgrade ccaa
   dict$variable <- gsub("ccaa", "b_ccaa", dict$variable, fixed = TRUE)
-  # Upgrade nuts
   dict$variable <- gsub("nuts", "c_nuts", dict$variable, fixed = TRUE)
+  dict
+}
 
+translate_source_to_keys <- function(sourcevar, dict) {
   names_dict <- unique(dict[
     grep("name", dict$variable, fixed = TRUE),
     c("key", "value")
   ])
 
-  sourcevar_lower <- tolower(sourcevar)
-  tokeys <- countrycode::countrycode(
-    sourcevar_lower,
+  countrycode::countrycode(
+    tolower(sourcevar),
     origin = "value",
     destination = "key",
     custom_dict = names_dict,
     nomatch = "NOMATCH"
   )
+}
 
-  if (any(tokeys == "NOMATCH")) {
-    cli::cli_alert_warning(paste0(
-      "No match found ",
-      "for {.str {sourcevar[tokeys == 'NOMATCH']}}."
-    ))
-  }
-
-  # Create lang dict
+translation_lang_dict <- function(dict, lang) {
   dict_tolang <- unique(dict[grep(paste0("name.", lang), dict$variable), ])
-
-  # Order using short names.
   shrt <- grep("short", dict_tolang$variable, fixed = TRUE)
-
   dict_tolang[shrt, ]$variable <- paste0("aa", dict_tolang[shrt, ]$variable)
 
-  dict_tolang <- unique(dict_tolang[
+  unique(dict_tolang[
     order(dict_tolang$variable),
     c("key", "value")
   ])
-  namestrans <- lapply(seq_along(tokeys), function(x) {
+}
+
+translate_keys_to_lang <- function(tokeys, dict_tolang, all) {
+  lapply(seq_along(tokeys), function(x) {
     if (tokeys[x] == "NOMATCH") {
       return(NA)
     }
@@ -324,12 +321,13 @@ esp_dict_translate <- function(sourcevar, lang = "en", all = FALSE) {
     }
     unname(all_trans)
   })
+}
 
+format_translation_output <- function(namestrans, sourcevar, all) {
   if (all) {
     names(namestrans) <- sourcevar
-  } else {
-    namestrans <- unlist(namestrans)
+    return(namestrans)
   }
 
-  namestrans
+  unlist(namestrans)
 }

--- a/R/esp-dict.R
+++ b/R/esp-dict.R
@@ -67,17 +67,7 @@ esp_dict_region_code <- function(
   origin <- match_arg_pretty(origin, validvars)
   destination <- match_arg_pretty(destination, validvars)
 
-  # Manually replace
-  sourcevar <- gsub("Ciudad de ceuta", "Ceuta", sourcevar, ignore.case = TRUE)
-  sourcevar <- gsub(
-    "Ciudad de melilla",
-    "Melilla",
-    sourcevar,
-    ignore.case = TRUE
-  )
-  sourcevar <- gsub("sta. cruz", "Santa Cruz", sourcevar, ignore.case = TRUE)
-  sourcevar <- gsub("sta cruz", "Santa Cruz", sourcevar, ignore.case = TRUE)
-
+  sourcevar <- normalize_region_sourcevar(sourcevar)
   initsourcevar <- sourcevar
 
   if (origin == destination && origin == "text") {
@@ -91,117 +81,138 @@ esp_dict_region_code <- function(
     return(initsourcevar)
   }
 
-  # Create dict
-  dict <- names_full
+  if (origin == "text") {
+    sourcevar <- text_to_nuts_sourcevar(sourcevar, initsourcevar, destination)
+    origin <- "nuts"
+  }
 
-  names_dict <- unique(dict[
+  if (destination == "text") {
+    out <- region_code_to_text(sourcevar, origin)
+  } else {
+    out <- region_code_to_code(sourcevar, origin, destination)
+  }
+
+  sanitize_region_code_output(out, sourcevar, initsourcevar, destination)
+}
+
+normalize_region_sourcevar <- function(sourcevar) {
+  sourcevar <- gsub(
+    "Ciudad de ceuta",
+    "Ceuta",
+    sourcevar,
+    ignore.case = TRUE
+  )
+  sourcevar <- gsub(
+    "Ciudad de melilla",
+    "Melilla",
+    sourcevar,
+    ignore.case = TRUE
+  )
+  sourcevar <- gsub("sta. cruz", "Santa Cruz", sourcevar, ignore.case = TRUE)
+  gsub("sta cruz", "Santa Cruz", sourcevar, ignore.case = TRUE)
+}
+
+get_region_names_dict <- function() {
+  dict <- names_full
+  unique(dict[
     grep("name", dict$variable, fixed = TRUE),
     c("key", "value")
   ])
+}
 
-  # If text convert to nuts
+text_to_nuts_sourcevar <- function(sourcevar, initsourcevar, destination) {
+  sourcevar <- countrycode::countrycode(
+    tolower(sourcevar),
+    origin = "value",
+    destination = "key",
+    custom_dict = get_region_names_dict(),
+    nomatch = "NOMATCH"
+  )
 
-  if (origin == "text") {
-    sourcevar <- countrycode::countrycode(
-      tolower(sourcevar),
-      origin = "value",
-      destination = "key",
-      custom_dict = names_dict,
-      nomatch = "NOMATCH"
-    )
+  sourcevar <- countrycode::countrycode(
+    sourcevar,
+    origin = "key",
+    destination = "nuts",
+    custom_dict = get_master_nuts_nm(),
+    nomatch = "NOMATCH"
+  )
 
-    # Translate to nuts
-    sourcevar <- countrycode::countrycode(
-      sourcevar,
-      origin = "key",
-      destination = "nuts",
-      custom_dict = get_master_nuts_nm(),
-      nomatch = "NOMATCH"
-    )
+  sourcevar[sourcevar == "NOMATCH"] <- initsourcevar[sourcevar == "NOMATCH"]
 
-    # Replace NOMATCH
-    sourcevar[sourcevar == "NOMATCH"] <- initsourcevar[sourcevar == "NOMATCH"]
-    origin <- "nuts"
+  sourcevar[sourcevar == "ES3"] <- "ES30"
+  sourcevar[sourcevar == "ES7"] <- "ES70"
 
-    # By name, perform some replacements
-    # Madrid - CCAA
-    sourcevar[sourcevar == "ES3"] <- "ES30"
-
-    # Canary Islands - CCAA.
-    sourcevar[sourcevar == "ES7"] <- "ES70"
-
-    if (destination == "iso2") {
-      # Melilla - Prov
-      sourcevar[sourcevar == "ES64"] <- "ES640"
-
-      # Ceuta - Prov
-      sourcevar[sourcevar == "ES63"] <- "ES630"
-    }
-
-    if (destination == "cpro") {
-      nchar <- nchar(sourcevar)
-      sourcevar[nchar == 4] <- paste0(sourcevar[nchar == 4], "0")
-    }
+  if (destination == "iso2") {
+    sourcevar[sourcevar == "ES64"] <- "ES640"
+    sourcevar[sourcevar == "ES63"] <- "ES630"
   }
 
-  # Destination
-  if (destination == "text") {
-    sourcevar <- countrycode::countrycode(
-      sourcevar,
-      origin,
-      "nuts",
-      custom_dict = get_master_codes(),
-      nomatch = "NOMATCH"
-    )
-
-    dict_nutsall <- sf::st_drop_geometry(mapSpain::esp_nuts_2024)
-
-    out <- countrycode::countrycode(
-      sourcevar,
-      "NUTS_ID",
-      "NUTS_NAME",
-      custom_dict = dict_nutsall,
-      nomatch = "NOMATCH"
-    )
-  } else {
-    # Solve problems
-    if (origin == "nuts") {
-      # Melilla - Prov
-      sourcevar[sourcevar == "ES64"] <- "ES640"
-
-      # Ceuta - Prov
-      sourcevar[sourcevar == "ES63"] <- "ES630"
-    }
-
-    if (destination == "codauto") {
-      # Melilla - Prov
-      sourcevar[sourcevar == "ES640"] <- "ES64"
-
-      # Ceuta - Prov
-      sourcevar[sourcevar == "ES630"] <- "ES63"
-    }
-
-    out <- countrycode::countrycode(
-      sourcevar,
-      origin,
-      destination,
-      custom_dict = get_master_codes(),
-      nomatch = "NOMATCH"
-    )
-
-    # Baleares
-    if (destination == "cpro") {
-      out[sourcevar == "ES530"] <- "07"
-    }
-    # Ceuta
-    if (origin == "iso2" && destination == "codauto") {
-      out[sourcevar == "ES-CE"] <- "18"
-      out[sourcevar == "ES-ML"] <- "19"
-    }
+  if (destination == "cpro") {
+    nchar <- nchar(sourcevar)
+    sourcevar[nchar == 4] <- paste0(sourcevar[nchar == 4], "0")
   }
+
+  sourcevar
+}
+
+region_code_to_text <- function(sourcevar, origin) {
+  sourcevar <- countrycode::countrycode(
+    sourcevar,
+    origin,
+    "nuts",
+    custom_dict = get_master_codes(),
+    nomatch = "NOMATCH"
+  )
+
+  dict_nutsall <- sf::st_drop_geometry(mapSpain::esp_nuts_2024)
+
+  countrycode::countrycode(
+    sourcevar,
+    "NUTS_ID",
+    "NUTS_NAME",
+    custom_dict = dict_nutsall,
+    nomatch = "NOMATCH"
+  )
+}
+
+region_code_to_code <- function(sourcevar, origin, destination) {
+  if (origin == "nuts") {
+    sourcevar[sourcevar == "ES64"] <- "ES640"
+    sourcevar[sourcevar == "ES63"] <- "ES630"
+  }
+
+  if (destination == "codauto") {
+    sourcevar[sourcevar == "ES640"] <- "ES64"
+    sourcevar[sourcevar == "ES630"] <- "ES63"
+  }
+
+  out <- countrycode::countrycode(
+    sourcevar,
+    origin,
+    destination,
+    custom_dict = get_master_codes(),
+    nomatch = "NOMATCH"
+  )
+
+  if (destination == "cpro") {
+    out[sourcevar == "ES530"] <- "07"
+  }
+  if (origin == "iso2" && destination == "codauto") {
+    out[sourcevar == "ES-CE"] <- "18"
+    out[sourcevar == "ES-ML"] <- "19"
+  }
+
+  out
+}
+
+sanitize_region_code_output <- function(
+  out,
+  sourcevar,
+  initsourcevar,
+  destination
+) {
   out[out %in% c("XXXXX", "YYYYY")] <- "NOMATCH"
 
-  # Sanitize
   if (length(out[out != "NOMATCH"]) != length(sourcevar)) {
     cli::cli_alert_warning(paste0(
       "No match on {.arg destination = {.str {destination}}} found ",

--- a/R/esp-dict.R
+++ b/R/esp-dict.R
@@ -2,26 +2,8 @@
 #'
 #' @description
 #' Convert Spanish subdivision names or identifiers between different coding
-#' schemes, such as NUTS, ISO2 and province codes, or obtain human-readable
+#' schemes such as NUTS, ISO2 and province codes, or obtain human-readable
 #' names.
-#'
-#' @encoding UTF-8
-#' @family dictionary
-#' @rdname esp_dict
-#' @name esp_dict_region_code
-#' @export
-#'
-#' @return
-#'
-#' `esp_dict_region_code()` returns a character vector with converted
-#' subdivision identifiers or names. If a value cannot be matched the
-#' corresponding element will be `NA` and a warning is emitted via
-#' [cli::cli_alert_warning()].
-#'
-#' @param sourcevar Character string. Vector which contains the codes or names
-#'   to be converted.
-#' @param origin,destination Character string. Coding scheme of origin and
-#'   destination. One of `"text"`, `"nuts"`, `"iso2"`, `"codauto"` or `"cpro"`.
 #'
 #' @details
 #' The function uses internal dictionaries together with \CRANpkg{countrycode}
@@ -29,6 +11,24 @@
 #' returned unchanged. Mixing names from different administrative levels
 #' (for example Autonomous Community and province) may produce
 #' `NA` values for some entries.
+#'
+#' @param sourcevar Character string. Vector which contains the codes or names
+#'   to be converted.
+#' @param origin,destination Character string. Coding scheme of origin and
+#'   destination. One of `"text"`, `"nuts"`, `"iso2"`, `"codauto"` or `"cpro"`.
+#'
+#' @return
+#'
+#' `esp_dict_region_code()` returns a character vector with converted
+#' subdivision identifiers or names. If a value cannot be matched, the
+#' corresponding element will be `NA` and a warning is emitted via
+#' [cli::cli_alert_warning()].
+#'
+#' @family dictionary
+#' @encoding UTF-8
+#' @rdname esp_dict
+#' @name esp_dict_region_code
+#' @export
 #'
 #' @examples
 #' vals <- c("Errioxa", "Coruna", "Gerona", "Madrid")
@@ -222,20 +222,6 @@ sanitize_region_code_output <- function(
 }
 
 #'
-#' @rdname esp_dict
-#' @name esp_dict_translate
-#'
-#' @return
-#'
-#' `esp_dict_translate()` translates a vector of names from one language to
-#' another:
-#'   - If `all = FALSE`, a character vector with the translated name for each
-#'     element of `sourcevar`.
-#'   - If `all = TRUE`, a named `list` is returned where each element contains
-#'     all available translations for the corresponding input value.
-#'
-#' @export
-#'
 #' @param lang Character string. Target language code, available values:
 #'   - `"es"`: Spanish.
 #'   - `"en"`: English.
@@ -246,6 +232,20 @@ sanitize_region_code_output <- function(
 #' @param all Logical. If `TRUE` the function returns all possible translations
 #'   for each input as a named list. When `FALSE` (default) a single preferred
 #'   translation per input is returned as a character vector.
+#'
+#' @return
+#'
+#' `esp_dict_translate()` translates a vector of names from one language to
+#' another.
+#'   - If `all = FALSE`, a character vector with the translated name for each
+#'     element of `sourcevar`.
+#'   - If `all = TRUE`, a named `list` is returned where each element contains
+#'     all available translations for the corresponding input value.
+#'
+#' @rdname esp_dict
+#' @name esp_dict_translate
+#'
+#' @export
 #'
 #' @examples
 #' vals <- c("La Rioja", "Sevilla", "Madrid", "Jaen", "Orense", "Baleares")

--- a/R/esp-get-attributions.R
+++ b/R/esp-get-attributions.R
@@ -1,6 +1,3 @@
-#' @rdname esp_get_tiles
-#'
-#' @order 2
 #' @description
 #'
 #' `esp_get_attributions` gets the attribution of a tile provider defined as
@@ -8,6 +5,9 @@
 #'
 #' @seealso [giscoR::gisco_attributions()]
 #'
+#' @rdname esp_get_tiles
+#'
+#' @order 2
 #' @export
 esp_get_attributions <- function(type, options = NULL) {
   # Validate

--- a/R/esp-get-can-box.R
+++ b/R/esp-get-can-box.R
@@ -84,7 +84,7 @@ esp_get_can_box <- function(
 
   epsg <- as.character(epsg)
 
-  epsg <- match_arg_pretty(epsg, c("4258", "4326", "3035", "3857"))
+  epsg <- validate_epsg(epsg, c("4258", "4326", "3035", "3857"))
 
   df <- mapSpain::esp_nuts_2024
   can <- df[df$NUTS_ID == "ES7", ]
@@ -152,7 +152,7 @@ esp_get_can_box <- function(
 esp_get_can_provinces <- function(moveCAN = TRUE, epsg = "4258") {
   epsg <- as.character(epsg)
 
-  epsg <- match_arg_pretty(epsg, c("4258", "4326", "3035", "3857"))
+  epsg <- validate_epsg(epsg, c("4258", "4326", "3035", "3857"))
 
   # From CartoBase ANE: se89_mult_admin_provcan_l
   m <- c(

--- a/R/esp-get-can-box.R
+++ b/R/esp-get-can-box.R
@@ -13,19 +13,19 @@
 #' - `"left"` / `"right"`: decorative `LINESTRING` variants that follow
 #'   the western or eastern side of the islands respectively.
 #'
-#' @encoding UTF-8
-#' @family can_helpers
-#' @rdname esp_get_can_box
-#' @name esp_get_can_box
-#' @inheritParams esp_get_nuts
-#' @export
-#'
 #' @param style Character string. One of `"right"`, `"left"`, `"box"` or
 #'   `"poly"`. Default is `"right"`, see **Details**.
 #'
+#' @inheritParams esp_get_nuts
 #' @return
 #' An [`sf`][sf::st_sf] object: a `POLYGON` (when `style = "poly"`) or a
 #' `LINESTRING` (other styles).
+#'
+#' @family can_helpers
+#' @encoding UTF-8
+#' @rdname esp_get_can_box
+#' @name esp_get_can_box
+#' @export
 #'
 #' @examples
 #' provs <- esp_get_prov()
@@ -137,8 +137,6 @@ esp_get_can_box <- function(
 
 #' Canary Islands province separator line
 #'
-#' @rdname esp_get_can_box
-#'
 #' @description
 #' `esp_get_can_provinces()` returns a small `LINESTRING` used to mark the
 #' separator between the two provinces of the Canary Islands. This helper is
@@ -147,6 +145,8 @@ esp_get_can_box <- function(
 #' @source
 #' Coordinates of `esp_get_can_provinces()` derived from CartoBase ANE
 #' (`se89_mult_admin_provcan_l.shp`).
+#'
+#' @rdname esp_get_can_box
 #'
 #' @export
 esp_get_can_provinces <- function(moveCAN = TRUE, epsg = "4258") {

--- a/R/esp-get-can-box.R
+++ b/R/esp-get-can-box.R
@@ -123,10 +123,7 @@ esp_get_can_box <- function(
     lall <- sf::st_sfc(lall, crs = sf::st_crs(can))
   }
 
-  moving <- FALSE
-  moving <- isTRUE(moveCAN) | length(moveCAN) > 1
-
-  if (moving) {
+  if (is_moving_can(moveCAN)) {
     lall <- esp_move_can(lall, moveCAN = moveCAN)
   }
 
@@ -166,10 +163,7 @@ esp_get_can_provinces <- function(moveCAN = TRUE, epsg = "4258") {
   lall <- sf::st_linestring(sf::st_coordinates(m))
   lall <- sf::st_sfc(lall, crs = sf::st_crs(4326))
 
-  moving <- FALSE
-  moving <- isTRUE(moveCAN) | length(moveCAN) > 1
-
-  if (moving) {
+  if (is_moving_can(moveCAN)) {
     lall <- esp_move_can(lall, moveCAN = moveCAN)
   }
 

--- a/R/esp-get-capimun.R
+++ b/R/esp-get-capimun.R
@@ -7,12 +7,21 @@
 #' Note that this differs from the centroid of the boundaries of the
 #' municipality, returned by [esp_get_munic_siane()].
 #'
-#' @encoding UTF-8
+#' @details
+#' When using `region` you can use and mix names and NUTS codes (levels 1, 2 or
+#' 3), ISO codes (corresponding to level 2 or 3) or `"cpro"`
+#' (see [esp_codelist]).
+#'
+#' When calling a higher level (province, Autonomous Community or NUTS1), all
+#' the municipalities of that level will be added.
+#'
+#' @inheritParams esp_get_munic_siane
+#' @inherit esp_get_munic_siane
+#'
 #' @family political
 #' @family siane
 #' @family municipalities
-#' @inheritParams esp_get_munic_siane
-#' @inherit esp_get_munic_siane
+#' @encoding UTF-8
 #' @export
 #'
 #' @examplesIf esp_check_access()

--- a/R/esp-get-capimun.R
+++ b/R/esp-get-capimun.R
@@ -57,7 +57,7 @@ esp_get_capimun <- function(
   moveCAN = TRUE,
   rawcols = FALSE
 ) {
-  init_epsg <- match_arg_pretty(epsg, c("4326", "4258", "3035", "3857"))
+  init_epsg <- validate_epsg(epsg)
 
   url_penin <- paste0(
     "https://github.com/rOpenSpain/mapSpain/raw/sianedata/dist/",
@@ -69,92 +69,26 @@ esp_get_capimun <- function(
     "se89_3_urban_capimuni_p_y.gpkg"
   )
 
-  # Read from the URL when the file is not cached.
-  if (!cache) {
-    msg <- paste0("{.url ", url_penin, "}.")
-    make_msg("info", verbose, "Reading from", msg)
-
-    data_sf_penin <- read_geo_file_sf(url_penin)
-
-    msg <- paste0("{.url ", url_can, "}.")
-    make_msg("info", verbose, "Reading from", msg)
-
-    data_sf_can <- read_geo_file_sf(url_can)
-
-    data_sf <- rbind_fill(list(data_sf_penin, data_sf_can))
-  } else {
-    file_local_penin <- download_url(
-      url_penin,
-      cache_dir = cache_dir,
-      subdir = "siane",
-      update_cache = update_cache,
-      verbose = verbose
-    )
-
-    file_local_can <- download_url(
-      url_can,
-      cache_dir = cache_dir,
-      subdir = "siane",
-      update_cache = update_cache,
-      verbose = verbose
-    )
-
-    # Read the downloaded files.
-    data_sf <- lapply(c(file_local_penin, file_local_can), read_geo_file_sf)
-
-    data_sf <- rbind_fill(data_sf)
-    if (is.null(data_sf)) {
-      return(NULL)
-    }
+  data_sf <- read_siane_files(
+    c(url_penin, url_can),
+    cache = cache,
+    update_cache = update_cache,
+    cache_dir = cache_dir,
+    verbose = verbose
+  )
+  if (is.null(data_sf)) {
+    return(NULL)
   }
   data_sf <- sf::st_transform(data_sf, as.double(init_epsg))
 
   data_sf <- siane_filter_year(data_sf = data_sf, year = year)
-  # Normalize names.
-  data_sf$LAU_CODE <- data_sf$id_ine
-  data_sf$name <- data_sf$rotulo
-  data_sf$cpro <- substr(data_sf$id_ine, 1, 2)
+  data_sf <- add_municipal_metadata(data_sf, "id_ine", "rotulo")
 
-  idprov <- sort(unique(mapSpain::esp_codelist$cpro))
-  data_sf$cmun <- ifelse(
-    substr(data_sf$LAU_CODE, 1, 2) %in% idprov,
-    substr(data_sf$LAU_CODE, 3, 8),
-    NA
-  )
-
-  cod <- unique(mapSpain::esp_codelist[, c(
-    "codauto",
-    "ine.ccaa.name",
-    "cpro",
-    "ine.prov.name"
-  )])
-
-  data_sf <- merge(data_sf, cod, by = "cpro", all.x = TRUE, no.dups = TRUE)
-
-  munic <- ensure_null(munic)
-
-  if (!is.null(munic)) {
-    munic <- paste(munic, collapse = "|")
-    data_sf <- data_sf[grep(munic, data_sf$name, ignore.case = TRUE), ]
-  }
-  region <- ensure_null(region)
-
-  if (!is.null(region)) {
-    tonuts <- convert_to_nuts_prov(region)
-    # Filter to selected provinces.
-    df <- unique(mapSpain::esp_codelist[, c("nuts3.code", "cpro")])
-    df <- df[df$nuts3.code %in% tonuts, "cpro"]
-    toprov <- unique(df$cpro)
-    data_sf <- data_sf[data_sf$cpro %in% toprov, ]
-  }
+  data_sf <- filter_by_name_pattern(data_sf, munic, "name")
+  data_sf <- filter_by_cpro_region(data_sf, region)
 
   if (nrow(data_sf) == 0) {
-    cli::cli_alert_warning(paste0(
-      "The combination of {.arg region}, {.arg munic} or both does not ",
-      "return any results."
-    ))
-    cli::cli_alert_info("Returning empty {.cls sf} object.")
-    return(data_sf)
+    return(return_empty_combination_sf(data_sf, "munic"))
   }
 
   # Move the Canary Islands.

--- a/R/esp-get-ccaa-siane.R
+++ b/R/esp-get-ccaa-siane.R
@@ -1,5 +1,20 @@
 #' Autonomous Communities of Spain - SIANE
 #'
+#' @param year Character string or number. Release year, it must be in
+#'   formats `YYYY` (assuming end of year) or `YYYY-MM-DD`. Historical
+#'   information starts as of 2005.
+#' @param resolution Character string or number. Resolution of the geospatial
+#'   data. One of:
+#'   - "10": 1:10 million.
+#'   - "6.5": 1:6.5 million.
+#'   - "3": 1:3 million.
+#'
+#' @param rawcols Logical. Setting this to `TRUE` will add the raw columns of
+#'   the resulting object as provided by IGN.
+#'
+#' @inheritParams esp_get_nuts
+#' @inheritParams esp_get_ccaa
+#' @inherit esp_get_ccaa description return details
 #' @source
 #' CartoBase ANE provided by Instituto Geografico Nacional (IGN),
 #' <http://www.ign.es/web/ign/portal>. Years available are 2005 up to today.
@@ -19,25 +34,10 @@
 #' Data distributed through the `sianedata` data branch, see
 #' <https://github.com/rOpenSpain/mapSpain/tree/sianedata>.
 #'
-#' @encoding UTF-8
 #' @family political
 #' @family siane
-#' @inheritParams esp_get_nuts
-#' @inheritParams esp_get_ccaa
-#' @inherit esp_get_ccaa description return details
+#' @encoding UTF-8
 #' @export
-#'
-#' @param year Character string or number. Release year, it must be in
-#'   formats `YYYY` (assuming end of year) or `YYYY-MM-DD`. Historical
-#'   information starts as of 2005.
-#' @param resolution Character string or number. Resolution of the geospatial
-#'   data. One of:
-#'   - "10": 1:10 million.
-#'   - "6.5": 1:6.5 million.
-#'   - "3": 1:3 million.
-#'
-#' @param rawcols Logical. Setting this to `TRUE` will add the raw columns of
-#'   the resulting object as provided by IGN.
 #'
 #' @examplesIf esp_check_access()
 #' ccaas1 <- esp_get_ccaa_siane()
@@ -108,12 +108,12 @@ esp_get_ccaa_siane <- function(
   data_sf$lab <- gsub("/Euskadi", "", data_sf$lab, fixed = TRUE)
   data_sf$codauto <- esp_dict_region_code(data_sf$lab, destination = "codauto")
 
-  # Filter CCAA
+  # Filter Autonomous Communities.
   nuts_id <- ensure_null(ccaa)
 
   if (!is.null(nuts_id)) {
     nuts_id <- convert_to_nuts_ccaa(nuts_id)
-    # Get CCAA metadata.
+    # Get Autonomous Community metadata.
     df <- mapSpain::esp_codelist
     dfl2 <- df[df$nuts2.code %in% nuts_id, ]$codauto
     dfl3 <- df[df$nuts3.code %in% nuts_id, ]$codauto

--- a/R/esp-get-ccaa-siane.R
+++ b/R/esp-get-ccaa-siane.R
@@ -67,7 +67,7 @@ esp_get_ccaa_siane <- function(
   moveCAN = TRUE,
   rawcols = FALSE
 ) {
-  init_epsg <- match_arg_pretty(epsg, c("4326", "4258", "3035", "3857"))
+  init_epsg <- validate_epsg(epsg)
   res <- match_arg_pretty(resolution)
   res <- gsub("6.5", "6m5", res)
 
@@ -85,43 +85,15 @@ esp_get_ccaa_siane <- function(
     "_admin_ccaa_a_y.gpkg"
   )
 
-  # Read from the URL when the file is not cached.
-  if (!cache) {
-    msg <- paste0("{.url ", url_penin, "}.")
-    make_msg("info", verbose, "Reading from", msg)
-
-    data_sf_penin <- read_geo_file_sf(url_penin)
-
-    msg <- paste0("{.url ", url_can, "}.")
-    make_msg("info", verbose, "Reading from", msg)
-
-    data_sf_can <- read_geo_file_sf(url_can)
-
-    data_sf <- rbind_fill(list(data_sf_penin, data_sf_can))
-  } else {
-    file_local_penin <- download_url(
-      url_penin,
-      cache_dir = cache_dir,
-      subdir = "siane",
-      update_cache = update_cache,
-      verbose = verbose
-    )
-
-    file_local_can <- download_url(
-      url_can,
-      cache_dir = cache_dir,
-      subdir = "siane",
-      update_cache = update_cache,
-      verbose = verbose
-    )
-
-    # Read the downloaded files.
-    data_sf <- lapply(c(file_local_penin, file_local_can), read_geo_file_sf)
-
-    data_sf <- rbind_fill(data_sf)
-    if (is.null(data_sf)) {
-      return(NULL)
-    }
+  data_sf <- read_siane_files(
+    c(url_penin, url_can),
+    cache = cache,
+    update_cache = update_cache,
+    cache_dir = cache_dir,
+    verbose = verbose
+  )
+  if (is.null(data_sf)) {
+    return(NULL)
   }
 
   data_sf <- siane_filter_year(data_sf = data_sf, year = year)
@@ -159,9 +131,7 @@ esp_get_ccaa_siane <- function(
   data_sf <- merge(data_sf, df, all.x = TRUE)
 
   # Paste nuts1
-  dfnuts <- mapSpain::esp_codelist
-  dfnuts <- unique(dfnuts[, c("nuts2.code", "nuts1.code", "nuts1.name")])
-  data_sf <- merge(data_sf, dfnuts, all.x = TRUE)
+  data_sf <- merge(data_sf, get_nuts1_codes_df(), all.x = TRUE)
 
   # Move the Canary Islands.
   data_sf <- move_can(data_sf, moveCAN)

--- a/R/esp-get-ccaa.R
+++ b/R/esp-get-ccaa.R
@@ -107,10 +107,7 @@ esp_get_ccaa <- function(ccaa = NULL, moveCAN = TRUE, ...) {
   data_sf <- merge(data_sf, df, all.x = TRUE)
 
   # Paste nuts1
-  dfnuts <- mapSpain::esp_codelist
-  dfnuts <- unique(dfnuts[, c("nuts2.code", "nuts1.code", "nuts1.name")])
-
-  data_sf <- merge(data_sf, dfnuts, all.x = TRUE)
+  data_sf <- merge(data_sf, get_nuts1_codes_df(), all.x = TRUE)
 
   data_sf <- data_sf[, unique(c(colnames(df), "nuts1.code", "nuts1.name"))]
 
@@ -120,34 +117,4 @@ esp_get_ccaa <- function(ccaa = NULL, moveCAN = TRUE, ...) {
   data_sf <- sanitize_sf(data_sf)
 
   data_sf
-}
-
-get_ccaa_codes_df <- function() {
-  getnames <- c(
-    "codauto",
-    "iso2.ccaa.code",
-    "nuts1.code",
-    "nuts2.code",
-    "ine.ccaa.name",
-    "iso2.ccaa.name.es",
-    "iso2.ccaa.name.ca",
-    "iso2.ccaa.name.gl",
-    "iso2.ccaa.name.eu",
-    "nuts2.name",
-    "cldr.ccaa.name.en",
-    "cldr.ccaa.name.es",
-    "cldr.ccaa.name.ca",
-    "cldr.ccaa.name.ga",
-    "cldr.ccaa.name.eu",
-    "ccaa.shortname.en",
-    "ccaa.shortname.es",
-    "ccaa.shortname.ca",
-    "ccaa.shortname.ga",
-    "ccaa.shortname.eu"
-  )
-  df_ccaa <- mapSpain::esp_codelist
-  df_ccaa <- df_ccaa[, getnames]
-  df_end <- unique(df_ccaa)
-  df_end <- df_end[order(df_end$codauto), ]
-  df_end
 }

--- a/R/esp-get-ccaa.R
+++ b/R/esp-get-ccaa.R
@@ -6,21 +6,6 @@
 #' Spain](https://en.wikipedia.org/wiki/Autonomous_communities_of_Spain) at a
 #' specified scale.
 #'
-#' @encoding UTF-8
-#' @family political
-#' @family gisco
-#' @inheritParams esp_get_nuts
-#' @inheritDotParams esp_get_nuts -nuts_level -region
-#' @inherit esp_get_nuts
-#' @export
-#'
-#' @rdname esp_get_ccaa
-#' @name esp_get_ccaa
-#'
-#' @param ccaa Character string. A vector of names, codes or both for
-#'   Autonomous Communities, or `NULL` to get all the Autonomous Communities.
-#'   See **Details**.
-#'
 #' @details
 #' When using `ccaa` you can use and mix names and NUTS codes (levels 1 or 2),
 #' ISO codes (corresponding to level 2) or `codauto` (see [esp_codelist]).
@@ -28,6 +13,22 @@
 #'
 #' When calling a NUTS1 level, all the Autonomous Communities of that level
 #' will be added.
+#'
+#' @param ccaa Character string. A vector of names, codes or both for
+#'   Autonomous Communities, or `NULL` to get all the Autonomous Communities.
+#'   See **Details**.
+#'
+#' @inheritParams esp_get_nuts
+#' @inheritDotParams esp_get_nuts -nuts_level -region
+#' @inherit esp_get_nuts
+#'
+#' @family political
+#' @family gisco
+#' @encoding UTF-8
+#' @rdname esp_get_ccaa
+#' @name esp_get_ccaa
+#'
+#' @export
 #'
 #' @examples
 #' ccaa <- esp_get_ccaa()
@@ -37,7 +38,7 @@
 #' ggplot(ccaa) +
 #'   geom_sf()
 #'
-#' # Random CCAA
+#' # Random Autonomous Communities
 #' random_ccaa <- esp_get_ccaa(ccaa = c(
 #'   "Euskadi",
 #'   "Catalunya",
@@ -52,7 +53,7 @@
 #'   geom_sf_label(aes(label = codauto), alpha = 0.3) +
 #'   coord_sf(crs = 3857)
 #'
-#' # All CCAA of a Zone plus an addition
+#' # All Autonomous Communities of a NUTS1 region plus an addition
 #'
 #' mixed <- esp_get_ccaa(ccaa = c("La Rioja", "Noroeste"))
 #'
@@ -102,7 +103,7 @@ esp_get_ccaa <- function(ccaa = NULL, moveCAN = TRUE, ...) {
   data_sf$nuts2.code <- data_sf$NUTS_ID
   data_sf <- data_sf[, "nuts2.code"]
 
-  # Get CCAA metadata.
+  # Get Autonomous Community metadata.
   df <- get_ccaa_codes_df()
   data_sf <- merge(data_sf, df, all.x = TRUE)
 

--- a/R/esp-get-comarca.R
+++ b/R/esp-get-comarca.R
@@ -99,7 +99,7 @@ esp_get_comarca <- function(
   cache_dir = NULL,
   verbose = FALSE
 ) {
-  init_epsg <- match_arg_pretty(epsg, c("4326", "4258", "3035", "3857"))
+  init_epsg <- validate_epsg(epsg)
   type <- match_arg_pretty(type)
 
   # URL
@@ -119,48 +119,25 @@ esp_get_comarca <- function(
 
   url <- paste0(api_entry, filename)
 
-  file_local <- download_url(
+  data_sf <- download_and_read_geo_file(
     url,
-    cache_dir = cache_dir,
     subdir = "comarcas",
     update_cache = update_cache,
+    cache_dir = cache_dir,
     verbose = verbose
   )
 
-  if (is.null(file_local)) {
+  if (is.null(data_sf)) {
     return(NULL)
   }
 
-  # Read the downloaded file.
-  data_sf <- read_geo_file_sf(file_local)
   data_sf <- sf::st_transform(data_sf, as.double(init_epsg))
 
-  comarca <- ensure_null(comarca)
-
-  if (!is.null(comarca)) {
-    comarca <- paste(comarca, collapse = "|")
-    data_sf <- data_sf[grep(comarca, data_sf$name, ignore.case = TRUE), ]
-  }
-  region <- ensure_null(region)
-
-  if (!is.null(region)) {
-    tonuts <- convert_to_nuts_prov(region)
-
-    # Filter to selected provinces.
-    df <- unique(mapSpain::esp_codelist[, c("nuts3.code", "cpro")])
-    df <- df[df$nuts3.code %in% tonuts, "cpro"]
-    toprov <- unique(df$cpro)
-
-    data_sf <- data_sf[data_sf$cpro %in% toprov, ]
-  }
+  data_sf <- filter_by_name_pattern(data_sf, comarca, "name")
+  data_sf <- filter_by_cpro_region(data_sf, region)
 
   if (nrow(data_sf) == 0) {
-    cli::cli_alert_warning(paste0(
-      "The combination of {.arg region}, {.arg comarca} or both does not ",
-      "return any results."
-    ))
-    cli::cli_alert_info("Returning empty {.cls sf} object.")
-    return(data_sf)
+    return(return_empty_combination_sf(data_sf, "comarca"))
   }
 
   # Move the Canary Islands.

--- a/R/esp-get-comarca.R
+++ b/R/esp-get-comarca.R
@@ -1,4 +1,4 @@
-#' 'Comarcas' of Spain
+#' Comarcas of Spain
 #'
 #' @description
 #' Returns
@@ -7,23 +7,6 @@
 #' traditional informal territorial divisions, comprising several municipalities
 #' sharing geographical, economic or cultural traits, typically with
 #' poorly defined limits.
-#'
-#' @source
-#' INE: PC_Axis files, IGN, Ministry of Agriculture, Fisheries and Food (MAPA).
-#'
-#' @encoding UTF-8
-#' @family political
-#' @inheritParams esp_get_prov
-#' @inherit esp_get_nuts
-#' @export
-#'
-#' @param region Character string. A vector of names, codes or both for
-#'   provinces, or `NULL` to get all the comarcas. See **Details**.
-#' @param comarca Character string. A name or [`regex`][base::grep()] expression
-#'   with the names of the required comarcas. `NULL` will return all the
-#'   possible comarcas.
-#' @param type Character string. One of `"INE"`, `"IGN"`, `"AGR"`, `"LIV"`.
-#'   Type of comarca to return, see **Details**.
 #'
 #' @details
 #' When using `region` you can use and mix names and NUTS codes
@@ -35,7 +18,7 @@
 #'
 #' # About comarcas
 #'
-#' 'Comarcas' (English equivalent: district, county, area or zone) does not
+#' Comarcas (English equivalent: district, county, area or zone) do not
 #' always have a formal legal status. They correspond mainly to natural areas
 #' (valleys, river basins and similar areas), historical regions or ancient
 #' kingdoms.
@@ -49,7 +32,7 @@
 #'
 #' `esp_get_comarca()` can retrieve several types of comarcas, each one
 #' provided under different classification criteria.
-#' - `"INE"`: Comarcas as defined by the National Statistics Institute (INE).
+#' - `"INE"`: Comarcas defined by the National Statistics Institute (INE).
 #' - `"IGN"`: Official comarcas, only available in some Autonomous Communities,
 #'   provided by the National Geographic Institute.
 #' - `"AGR"`: Agrarian comarcas defined by the Ministry of Agriculture,
@@ -57,12 +40,30 @@
 #' - `"LIV"`: Livestock comarcas defined by the Ministry of Agriculture,
 #'   Fisheries and Food (MAPA).
 #'
+#' @param region Character string. A vector of names, codes or both for
+#'   provinces, or `NULL` to get all the comarcas. See **Details**.
+#' @param comarca Character string. A name or [`regex`][base::grep()] expression
+#'   with the names of the required comarcas. `NULL` will return all the
+#'   possible comarcas.
+#' @param type Character string. One of `"INE"`, `"IGN"`, `"AGR"`, `"LIV"`.
+#'   Type of comarca to return. See **Details**.
+#'
+#' @inheritParams esp_get_prov
+#' @inheritParams esp_get_nuts
+#' @inherit esp_get_nuts return
+#' @source
+#' INE: PC_Axis files, IGN, Ministry of Agriculture, Fisheries and Food (MAPA).
+#'
 #' @note
 #' The use of the information contained on the
 #' [INE website](https://www.ine.es/en/index.htm) may be carried out by users or
 #' re-use agents, at their own risk, and they will be the sole liable parties
 #' in the case of having to answer to third parties due to damages arising
 #' from such use.
+#'
+#' @family political
+#' @encoding UTF-8
+#' @export
 #'
 #' @examplesIf esp_check_access()
 #' \donttest{
@@ -80,7 +81,7 @@
 #' ggplot(rec) +
 #'   geom_sf(aes(fill = t_comarca))
 #'
-#' # Legal Comarcas of Catalunya
+#' # Legal comarcas of Catalunya
 #'
 #' comarcas_cat <- esp_get_comarca("Catalunya", type = "IGN")
 #'

--- a/R/esp-get-countries-siane.R
+++ b/R/esp-get-countries-siane.R
@@ -36,44 +36,32 @@ esp_get_countries_siane <- function(
   verbose = FALSE,
   country = NULL
 ) {
-  init_epsg <- match_arg_pretty(epsg, c("4326", "4258", "3035", "3857"))
+  init_epsg <- validate_epsg(epsg)
 
   url <- paste0(
     "https://github.com/rOpenSpain/mapSpain/raw/sianedata/dist/",
     "ww84_60_admin_pais_a.gpkg"
   )
 
-  # Read from the URL when the file is not cached.
-  if (!cache) {
-    msg <- paste0("{.url ", url, "}.")
-    make_msg("info", verbose, "Reading from", msg)
-
-    data_sf <- read_geo_file_sf(url)
-  } else {
-    file_local <- download_url(
-      url,
-      cache_dir = cache_dir,
-      subdir = "siane",
-      update_cache = update_cache,
-      verbose = verbose
-    )
-
-    # Read the downloaded files.
-    data_sf <- read_geo_file_sf(file_local)
-
-    if (is.null(data_sf)) {
-      return(NULL)
-    }
+  data_sf <- read_siane_files(
+    url,
+    cache = cache,
+    update_cache = update_cache,
+    cache_dir = cache_dir,
+    verbose = verbose
+  )
+  if (is.null(data_sf)) {
+    return(NULL)
   }
   data_sf <- sf::st_transform(data_sf, as.double(init_epsg))
   data_sf <- siane_filter_year(data_sf = data_sf, year = year)
   data_sf <- filter_country(data_sf, country)
 
   if (nrow(data_sf) == 0) {
-    cli::cli_alert_warning(paste0(
+    data_sf <- return_empty_sf(
+      data_sf,
       "The values in {.arg country} do not return any results."
-    ))
-    cli::cli_alert_info("Returning empty {.cls sf} object.")
+    )
   }
 
   data_sf

--- a/R/esp-get-countries-siane.R
+++ b/R/esp-get-countries-siane.R
@@ -53,7 +53,7 @@ esp_get_countries_siane <- function(
   if (is.null(data_sf)) {
     return(NULL)
   }
-  data_sf <- sf::st_transform(data_sf, as.double(init_epsg))
+  data_sf <- sanitize_transform_sf(data_sf, init_epsg)
   data_sf <- siane_filter_year(data_sf = data_sf, year = year)
   data_sf <- filter_country(data_sf, country)
 

--- a/R/esp-get-countries-siane.R
+++ b/R/esp-get-countries-siane.R
@@ -1,4 +1,4 @@
-#' Countries of the World - SIANE
+#' Countries of the world - SIANE
 #'
 #' @description
 #' This dataset contains the administrative boundaries at country level of the
@@ -7,19 +7,19 @@
 #' The data included in this cartographic database do not imply any opinion of
 #' the IGN regarding its legal status.
 #'
-#' @encoding UTF-8
-#' @family political
-#' @family siane
-#' @inheritParams esp_get_ccaa_siane
-#' @inheritParams esp_get_prov
-#' @inherit esp_get_ccaa_siane source return
-#' @export
-#'
-#' @seealso [giscoR::gisco_get_countries()].
-#'
 #' @param country Character vector of country codes. It can be either a
 #'   vector of country names, a vector of ISO3 country codes or a vector of
 #'   ISO2 country codes. See also [countrycode::countrycode()].
+#'
+#' @inheritParams esp_get_ccaa_siane
+#' @inheritParams esp_get_prov
+#' @inherit esp_get_ccaa_siane source return
+#' @seealso [giscoR::gisco_get_countries()].
+#'
+#' @family political
+#' @family siane
+#' @encoding UTF-8
+#' @export
 #'
 #' @examplesIf esp_check_access()
 #' cntries <- esp_get_countries_siane()

--- a/R/esp-get-grid-BDN.R
+++ b/R/esp-get-grid-BDN.R
@@ -91,12 +91,12 @@ esp_get_grid_BDN <- function(
 
   url <- paste0(api_entry, filename)
 
-  data_sf <- download_url(
+  data_sf <- download_and_read_geo_file(
     url,
     name = filename,
-    cache_dir = cache_dir,
     subdir = "grid",
     update_cache = update_cache,
+    cache_dir = cache_dir,
     verbose = verbose
   )
 
@@ -104,7 +104,7 @@ esp_get_grid_BDN <- function(
     return(NULL)
   }
 
-  read_geo_file_sf(data_sf)
+  data_sf
 }
 
 #' @rdname esp_get_grid_BDN
@@ -146,12 +146,12 @@ esp_get_grid_BDN_ccaa <- function(
 
   url <- paste0(api_entry, filename)
 
-  data_sf <- download_url(
+  data_sf <- download_and_read_geo_file(
     url,
     name = filename,
-    cache_dir = cache_dir,
     subdir = "grid",
     update_cache = update_cache,
+    cache_dir = cache_dir,
     verbose = verbose
   )
 
@@ -159,5 +159,5 @@ esp_get_grid_BDN_ccaa <- function(
     return(NULL)
   }
 
-  read_geo_file_sf(data_sf)
+  data_sf
 }

--- a/R/esp-get-grid-BDN.R
+++ b/R/esp-get-grid-BDN.R
@@ -14,17 +14,21 @@
 #' These grids are useful for biodiversity analysis, environmental monitoring,
 #' and spatial statistical applications.
 #'
-#' @encoding UTF-8
-#' @family grids
-#' @inheritParams esp_get_nuts
-#' @inherit esp_get_nuts return
-#' @export
-#'
 #' @details
 #' The BDN provides standardized geographic grids for Spain that follow the
 #' Nature Data Bank's specifications. The data is downloaded from the
 #' `sianedata/MITECO/dist` data branch and is regularly updated.
 #'
+#' @param resolution Numeric. Resolution of the grid in kilometers. Must be one
+#'   of:
+#'   - `5`: 5x5 kilometer cells
+#'   - `10`: 10x10 kilometer cells (default)
+#' @param type Character. The geographic scope of the grid:
+#'   - `"main"`: Mainland Spain (default)
+#'   - `"canary"`: Canary Islands
+#'
+#' @inheritParams esp_get_nuts
+#' @inherit esp_get_nuts return
 #' @source
 #' Data sourced from the Banco de Datos de la Naturaleza (BDN). See the
 #' repository structure:
@@ -38,13 +42,9 @@
 #'       "bdn-cart-aux-descargas-ccaa.html>."))
 #' ```
 #'
-#' @param resolution Numeric. Resolution of the grid in kilometers. Must be one
-#'   of:
-#'   - `5`: 5x5 kilometer cells
-#'   - `10`: 10x10 kilometer cells (default)
-#' @param type Character. The geographic scope of the grid:
-#'   - `"main"`: Mainland Spain (default)
-#'   - `"canary"`: Canary Islands
+#' @family grids
+#' @encoding UTF-8
+#' @export
 #'
 #' @examplesIf esp_check_access()
 #' \donttest{
@@ -107,9 +107,6 @@ esp_get_grid_BDN <- function(
   data_sf
 }
 
-#' @rdname esp_get_grid_BDN
-#' @export
-#'
 #' @description
 #' `esp_get_grid_BDN_ccaa()` provides higher-resolution 1x1 kilometer grids
 #' for specific Autonomous Communities, useful for regional analysis with
@@ -121,6 +118,9 @@ esp_get_grid_BDN <- function(
 #'
 #' @seealso
 #' [esp_get_ccaa()]
+#'
+#' @rdname esp_get_grid_BDN
+#' @export
 #'
 esp_get_grid_BDN_ccaa <- function(
   ccaa,

--- a/R/esp-get-grid-EEA.R
+++ b/R/esp-get-grid-EEA.R
@@ -5,11 +5,10 @@
 #'
 #' This function is defunct as the source file is not available any more.
 #'
-#' @family deprecated functions
-#' @keywords internal
-#' @encoding UTF-8
-#' @export
+#' @param resolution Resolution of the grid in kilometers. Can be `1`, `10`
+#'   or `100`.
 #'
+#' @inheritParams esp_get_grid_BDN
 #' @return A [`sf`][sf::st_sf] `POLYGON`.
 #'
 #' @source
@@ -22,10 +21,11 @@
 #'
 #' ```
 #'
-#' @param resolution Resolution of the grid in kilometers. Can be `1`, `10`
-#'   or `100`.
+#' @family deprecated functions
+#' @keywords internal
+#' @encoding UTF-8
+#' @export
 #'
-#' @inheritParams esp_get_grid_BDN
 esp_get_grid_EEA <- function(
   resolution = 100,
   type = "main",

--- a/R/esp-get-grid-ESDAC.R
+++ b/R/esp-get-grid-ESDAC.R
@@ -66,16 +66,17 @@ esp_get_grid_ESDAC <- function(
   }
   # nocov end
 
-  file_local <- download_url(
+  data_sf <- download_and_read_geo_file(
     url,
-    cache_dir = cache_dir,
     subdir = "grid",
     update_cache = update_cache,
-    verbose = verbose
+    cache_dir = cache_dir,
+    verbose = verbose,
+    shp_hint = shp_hint
   )
-  if (is.null(file_local)) {
-    return(file_local)
+  if (is.null(data_sf)) {
+    return(NULL)
   }
 
-  read_geo_file_sf(file_local, shp_hint = shp_hint)
+  data_sf
 }

--- a/R/esp-get-grid-ESDAC.R
+++ b/R/esp-get-grid-ESDAC.R
@@ -4,6 +4,11 @@
 #' Loads a [`sf`][sf::st_sf] `POLYGON` with the geographic grids of Spain as
 #' provided by the European Soil Data Centre (ESDAC).
 #'
+#' @param resolution Numeric. Resolution of the grid in kilometers. Can be `1`
+#'   or `10`.
+#'
+#' @inheritParams esp_get_grid_EEA
+#' @inherit esp_get_grid_EEA return
 #' @source
 #' [EEA reference
 #' grid](https://esdac.jrc.ec.europa.eu/content/european-reference-grids).
@@ -16,14 +21,9 @@
 #' - European Soil Data Centre (ESDAC), esdac.jrc.ec.europa.eu, European
 #'   Commission, Joint Research Centre.
 #'
-#' @encoding UTF-8
 #' @family grids
-#' @inheritParams esp_get_grid_EEA
-#' @inherit esp_get_grid_EEA return
+#' @encoding UTF-8
 #' @export
-#'
-#' @param resolution Numeric. Resolution of the grid in kilometers. Can be `1`
-#'   or `10`.
 #'
 #' @examplesIf esp_check_access()
 #' \dontrun{

--- a/R/esp-get-grid-MTN.R
+++ b/R/esp-get-grid-MTN.R
@@ -3,17 +3,6 @@
 #' @description
 #' Loads a [`sf`][sf::st_sf] `POLYGON` with the geographic grids of Spain.
 #'
-#' @source IGN data distributed through the `sianedata/MTN` data branch (see
-#' <https://github.com/rOpenSpain/mapSpain/tree/sianedata/MTN>).
-#'
-#' @encoding UTF-8
-#' @family grids
-#' @inheritParams esp_get_grid_EEA
-#' @inherit esp_get_grid_EEA return
-#' @export
-#'
-#' @param grid Name of the grid to be loaded. See **Details**.
-#'
 #' @details
 #' Metadata available on
 #' <https://github.com/rOpenSpain/mapSpain/tree/sianedata/MTN>.
@@ -86,6 +75,17 @@
 #' real grid of the MTN50, that is, the one that divides the current printed
 #' series of the map, taking into account the special distribution of the
 #' Canary Islands sheets.
+#'
+#' @param grid Name of the grid to be loaded. See **Details**.
+#'
+#' @inheritParams esp_get_grid_EEA
+#' @inherit esp_get_grid_EEA return
+#' @source IGN data distributed through the `sianedata/MTN` data branch (see
+#' <https://github.com/rOpenSpain/mapSpain/tree/sianedata/MTN>).
+#'
+#' @family grids
+#' @encoding UTF-8
+#' @export
 #'
 #' @examplesIf esp_check_access()
 #' \donttest{

--- a/R/esp-get-grid-MTN.R
+++ b/R/esp-get-grid-MTN.R
@@ -121,17 +121,13 @@ esp_get_grid_MTN <- function(
     "https://github.com/rOpenSpain/mapSpain/raw/sianedata/",
     "MTN/dist/MTN_grids.zip"
   )
-  file_local <- download_url(
+
+  download_unzip_read_geo_file(
     url,
-    cache_dir = cache_dir,
     subdir = "grid",
+    member = paste0(init_grid, ".gpkg"),
     update_cache = update_cache,
+    cache_dir = cache_dir,
     verbose = verbose
   )
-  if (is.null(file_local)) {
-    return(file_local)
-  }
-  path <- gsub(basename(file_local), "", file_local)
-  unzip(file_local, exdir = path, junkpaths = TRUE)
-  read_geo_file_sf(paste0(path, init_grid, ".gpkg"))
 }

--- a/R/esp-get-gridmap.R
+++ b/R/esp-get-gridmap.R
@@ -4,19 +4,6 @@
 #' Loads a hexbin map ([`sf`][sf::st_sf] object) or a map of squares with the
 #' boundaries of the provinces or Autonomous Communities of Spain.
 #'
-#' @encoding UTF-8
-#' @rdname esp_get_gridmap
-#' @name esp_get_gridmap
-#' @family political
-#' @export
-#' @inherit esp_get_nuts return
-#'
-#' @param prov,ccaa Character. A vector of names, codes or both for provinces
-#'   and Autonomous Communities, or `NULL` to get all the data. See
-#'   **Details**.
-#'
-#' @seealso [`esp_get_simpl`][esp_get_simpl].
-#'
 #' @details
 #'
 #' Hexbin (or grid) maps have an advantage over traditional choropleth maps.
@@ -34,6 +21,19 @@
 #' Results are provided in **EPSG:4258**, use [sf::st_transform()]
 #' to change the projection.
 #'
+#' @param prov,ccaa Character. A vector of names, codes or both for provinces
+#'   and Autonomous Communities, or `NULL` to get all the data. See
+#'   **Details**.
+#'
+#' @inherit esp_get_nuts return
+#'
+#' @seealso [`esp_get_simpl`][esp_get_simpl].
+#'
+#' @family political
+#' @encoding UTF-8
+#' @rdname esp_get_gridmap
+#' @name esp_get_gridmap
+#' @export
 #' @examplesIf esp_check_access()
 #' \donttest{
 #' esp <- esp_get_spain()
@@ -46,7 +46,7 @@
 #'   geom_sf(aes(fill = codauto), alpha = 0.3, show.legend = FALSE) +
 #'   geom_sf_text(aes(label = label), check_overlap = TRUE) +
 #'   theme_void() +
-#'   labs(title = "Hexbin: CCAA")
+#'   labs(title = "Hexbin: Autonomous Communities")
 #'
 #' hexprov <- esp_get_hex_prov()
 #'
@@ -64,7 +64,7 @@
 #'   geom_sf(aes(fill = codauto), alpha = 0.3, show.legend = FALSE) +
 #'   geom_sf_text(aes(label = label), check_overlap = TRUE) +
 #'   theme_void() +
-#'   labs(title = "Grid: CCAA")
+#'   labs(title = "Grid: Autonomous Communities")
 #'
 #' gridprov <- esp_get_grid_prov()
 #'

--- a/R/esp-get-gridmap.R
+++ b/R/esp-get-gridmap.R
@@ -115,13 +115,7 @@ get_gridmap_prov <- function(prov = NULL, type = "hex") {
   if (is.null(prov)) {
     return(data_sf)
   }
-  region <- convert_to_nuts_prov(prov)
-
-  dfcpro <- mapSpain::esp_codelist
-  dfcpro <- unique(dfcpro[, c("nuts3.code", "cpro")])
-  cprocodes <- unique(dfcpro[dfcpro$nuts3.code %in% region, ]$cpro)
-
-  data_sf <- data_sf[data_sf$cpro %in% cprocodes, ]
+  data_sf <- filter_by_cpro_region(data_sf, prov)
 
   data_sf
 }
@@ -139,8 +133,7 @@ get_gridmap_ccaa <- function(ccaa = NULL, type = "hex") {
   if (is.null(ccaa)) {
     return(data_sf)
   }
-  nuts_id <- convert_to_nuts_ccaa(ccaa)
-  data_sf <- data_sf[data_sf$nuts2.code %in% nuts_id, ]
+  data_sf <- filter_by_codauto_region(data_sf, ccaa)
 
   data_sf
 }

--- a/R/esp-get-hydrobasin.R
+++ b/R/esp-get-hydrobasin.R
@@ -5,19 +5,19 @@
 #' neighbouring river basins together with their associated groundwaters and
 #' coastal waters.
 #'
-#' @encoding UTF-8
-#' @family natural
-#' @inheritParams esp_get_ccaa_siane
-#' @inherit esp_get_ccaa_siane
-#' @export
+#' @details
+#' Metadata available on
+#' <https://github.com/rOpenSpain/mapSpain/tree/sianedata/>.
 #'
 #' @param domain Character string. Type of river basin district. Possible
 #'   values are `"land"`, including only the groundwaters area or `"landsea"`,
 #'   groundwaters and coastal waters.
 #'
-#' @details
-#' Metadata available on
-#' <https://github.com/rOpenSpain/mapSpain/tree/sianedata/>.
+#' @inheritParams esp_get_ccaa_siane
+#' @inherit esp_get_ccaa_siane return source
+#' @family natural
+#' @encoding UTF-8
+#' @export
 #'
 #' @examplesIf esp_check_access()
 #' \donttest{

--- a/R/esp-get-hydrobasin.R
+++ b/R/esp-get-hydrobasin.R
@@ -95,7 +95,7 @@ esp_get_hydrobasin <- function(
   if (is.null(data_sf)) {
     return(NULL)
   }
-  data_sf <- sf::st_transform(data_sf, as.double(init_epsg))
+  data_sf <- sanitize_transform_sf(data_sf, init_epsg)
 
   data_sf
 }

--- a/R/esp-get-hydrobasin.R
+++ b/R/esp-get-hydrobasin.R
@@ -50,7 +50,7 @@ esp_get_hydrobasin <- function(
   resolution = c(3, 6.5, 10),
   domain = c("land", "landsea")
 ) {
-  init_epsg <- match_arg_pretty(epsg, c("4326", "4258", "3035", "3857"))
+  init_epsg <- validate_epsg(epsg)
   domain <- match_arg_pretty(domain)
   res <- match_arg_pretty(resolution)
   res <- gsub("6.5", "6m5", res)
@@ -85,43 +85,15 @@ esp_get_hydrobasin <- function(
     )
   }
 
-  # Read from the URL when the file is not cached.
-  if (!cache) {
-    msg <- paste0("{.url ", url_penin, "}.")
-    make_msg("info", verbose, "Reading from", msg)
-
-    data_sf_penin <- read_geo_file_sf(url_penin)
-
-    msg <- paste0("{.url ", url_can, "}.")
-    make_msg("info", verbose, "Reading from", msg)
-
-    data_sf_can <- read_geo_file_sf(url_can)
-
-    data_sf <- rbind_fill(list(data_sf_penin, data_sf_can))
-  } else {
-    file_local_penin <- download_url(
-      url_penin,
-      cache_dir = cache_dir,
-      subdir = "siane",
-      update_cache = update_cache,
-      verbose = verbose
-    )
-
-    file_local_can <- download_url(
-      url_can,
-      cache_dir = cache_dir,
-      subdir = "siane",
-      update_cache = update_cache,
-      verbose = verbose
-    )
-
-    # Read the downloaded files.
-    data_sf <- lapply(c(file_local_penin, file_local_can), read_geo_file_sf)
-
-    data_sf <- rbind_fill(data_sf)
-    if (is.null(data_sf)) {
-      return(NULL)
-    }
+  data_sf <- read_siane_files(
+    c(url_penin, url_can),
+    cache = cache,
+    update_cache = update_cache,
+    cache_dir = cache_dir,
+    verbose = verbose
+  )
+  if (is.null(data_sf)) {
+    return(NULL)
   }
   data_sf <- sf::st_transform(data_sf, as.double(init_epsg))
 

--- a/R/esp-get-hypsobath.R
+++ b/R/esp-get-hypsobath.R
@@ -90,7 +90,7 @@ esp_get_hypsobath <- function(
   resolution = c(3, 6.5),
   spatialtype = c("area", "line")
 ) {
-  init_epsg <- match_arg_pretty(epsg, c("4326", "4258", "3035", "3857"))
+  init_epsg <- validate_epsg(epsg)
   res <- match_arg_pretty(resolution)
   res <- gsub("6.5", "6m5", res)
 
@@ -117,43 +117,15 @@ esp_get_hypsobath <- function(
     "_y.gpkg"
   )
 
-  # Read from the URL when the file is not cached.
-  if (!cache) {
-    msg <- paste0("{.url ", url_penin, "}.")
-    make_msg("info", verbose, "Reading from", msg)
-
-    data_sf_penin <- read_geo_file_sf(url_penin)
-
-    msg <- paste0("{.url ", url_can, "}.")
-    make_msg("info", verbose, "Reading from", msg)
-
-    data_sf_can <- read_geo_file_sf(url_can)
-
-    data_sf <- rbind_fill(list(data_sf_penin, data_sf_can))
-  } else {
-    file_local_penin <- download_url(
-      url_penin,
-      cache_dir = cache_dir,
-      subdir = "siane",
-      update_cache = update_cache,
-      verbose = verbose
-    )
-
-    file_local_can <- download_url(
-      url_can,
-      cache_dir = cache_dir,
-      subdir = "siane",
-      update_cache = update_cache,
-      verbose = verbose
-    )
-
-    # Read the downloaded files.
-    data_sf <- lapply(c(file_local_penin, file_local_can), read_geo_file_sf)
-
-    data_sf <- rbind_fill(data_sf)
-    if (is.null(data_sf)) {
-      return(NULL)
-    }
+  data_sf <- read_siane_files(
+    c(url_penin, url_can),
+    cache = cache,
+    update_cache = update_cache,
+    cache_dir = cache_dir,
+    verbose = verbose
+  )
+  if (is.null(data_sf)) {
+    return(NULL)
   }
   data_sf <- sf::st_transform(data_sf, as.double(init_epsg))
 

--- a/R/esp-get-hypsobath.R
+++ b/R/esp-get-hypsobath.R
@@ -7,11 +7,9 @@
 #' - **Bathymetry** is the measurement of the depth of water in oceans, rivers,
 #'   or lakes.
 #'
-#' @encoding UTF-8
-#' @family natural
-#' @inheritParams esp_get_ccaa_siane
-#' @inherit esp_get_ccaa_siane
-#' @export
+#' @details
+#' Metadata available on
+#' <https://github.com/rOpenSpain/mapSpain/tree/sianedata/>.
 #'
 #' @param resolution Character string or number. Resolution of the geospatial
 #'   data. One of:
@@ -21,9 +19,11 @@
 #' @param spatialtype Character string. Spatial type of the output. Use
 #'   `"area"` for `POLYGON` or `"line"` for `LINESTRING`.
 #'
-#' @details
-#' Metadata available on
-#' <https://github.com/rOpenSpain/mapSpain/tree/sianedata/>.
+#' @inheritParams esp_get_ccaa_siane
+#' @inherit esp_get_ccaa_siane return source
+#' @family natural
+#' @encoding UTF-8
+#' @export
 #'
 #' @examplesIf esp_check_access()
 #' \donttest{
@@ -46,7 +46,7 @@
 #'   tidyterra::hypso.colors(br_terrain, "wiki-2.0_hypso")
 #' )
 #'
-#' # Plot Canary Islands
+#' # Plot the Canary Islands
 #' ggplot(hypsobath) +
 #'   geom_sf(aes(fill = as.factor(val_inf)),
 #'     color = NA

--- a/R/esp-get-hypsobath.R
+++ b/R/esp-get-hypsobath.R
@@ -127,7 +127,7 @@ esp_get_hypsobath <- function(
   if (is.null(data_sf)) {
     return(NULL)
   }
-  data_sf <- sf::st_transform(data_sf, as.double(init_epsg))
+  data_sf <- sanitize_transform_sf(data_sf, init_epsg)
 
   data_sf
 }

--- a/R/esp-get-landwater.R
+++ b/R/esp-get-landwater.R
@@ -3,14 +3,9 @@
 #' @description
 #' Object representing rivers, lagoons, reservoirs and wetlands of Spain.
 #'
-#' @encoding UTF-8
-#' @family natural
-#' @inheritParams esp_get_ccaa_siane
-#' @inherit esp_get_ccaa_siane
-#' @export
-#'
-#' @rdname esp_get_landwater
-#' @name esp_get_landwater
+#' @details
+#' Metadata available on
+#' <https://github.com/rOpenSpain/mapSpain/tree/sianedata/>.
 #'
 #' @param resolution `r lifecycle::badge("deprecated")` character string.
 #'   Ignored, resolution `3` (the most detailed) will always be provided.
@@ -19,9 +14,14 @@
 #'   wetlands.
 #' @param name Character string or [`regex`][base::grep()] expression. Name of
 #'   the element(s) to be extracted.
-#' @details
-#' Metadata available on
-#' <https://github.com/rOpenSpain/mapSpain/tree/sianedata/>.
+#' @inheritParams esp_get_ccaa_siane
+#' @inherit esp_get_ccaa_siane return source
+#' @family natural
+#' @encoding UTF-8
+#' @rdname esp_get_landwater
+#' @name esp_get_landwater
+#'
+#' @export
 #'
 #' @examplesIf esp_check_access()
 #' \donttest{
@@ -95,7 +95,7 @@ esp_get_rivers <- function(
     )
 
     cli::cli_alert_info(
-      "Redirecting the arguments to {.fn mapSpain::esp_get_wetlands}"
+      "Redirecting the arguments to {.fn mapSpain::esp_get_wetlands}."
     )
 
     data_sf <- esp_get_wetlands(

--- a/R/esp-get-landwater.R
+++ b/R/esp-get-landwater.R
@@ -76,7 +76,7 @@ esp_get_rivers <- function(
   moveCAN = TRUE,
   name = NULL
 ) {
-  init_epsg <- match_arg_pretty(epsg, c("4326", "4258", "3035", "3857"))
+  init_epsg <- validate_epsg(epsg)
   spatialtype <- match_arg_pretty(spatialtype)
 
   if (lifecycle::is_present(resolution)) {
@@ -120,64 +120,34 @@ esp_get_rivers <- function(
     "se89_3_hidro_rio_l_y.gpkg"
   )
 
-  # Read from the URL when the file is not cached.
-  if (!cache) {
-    msg <- paste0("{.url ", url_penin, "}.")
-    make_msg("info", verbose, "Reading from", msg)
-
-    data_sf_penin <- read_geo_file_sf(url_penin)
-    data_sf_penin$codauto <- "XX"
-
-    msg <- paste0("{.url ", url_can, "}.")
-    make_msg("info", verbose, "Reading from", msg)
-
-    data_sf_can <- read_geo_file_sf(url_can)
-    data_sf_can$codauto <- "05"
-
-    data_sf <- rbind_fill(list(data_sf_penin, data_sf_can))
-  } else {
-    file_local_penin <- download_url(
-      url_penin,
-      cache_dir = cache_dir,
-      subdir = "siane",
-      update_cache = update_cache,
-      verbose = verbose
-    )
-
-    file_local_can <- download_url(
-      url_can,
-      cache_dir = cache_dir,
-      subdir = "siane",
-      update_cache = update_cache,
-      verbose = verbose
-    )
-
-    # Read the downloaded files.
-
-    ok_down <- ensure_null(c(file_local_penin, file_local_can))
-    if (is.null(ok_down)) {
-      return(NULL)
-    }
-
-    data_sf_penin <- read_geo_file_sf(file_local_penin)
-    data_sf_penin$codauto <- "XX"
-
-    data_sf_can <- read_geo_file_sf(file_local_can)
-    data_sf_can$codauto <- "05"
-
-    data_sf <- rbind_fill(list(data_sf_penin, data_sf_can))
+  data_sf <- read_siane_files(
+    c(url_penin, url_can),
+    cache = cache,
+    update_cache = update_cache,
+    cache_dir = cache_dir,
+    verbose = verbose,
+    codauto = c("XX", "05")
+  )
+  if (is.null(data_sf)) {
+    return(NULL)
   }
 
-  # Add descriptions
-  # Persist. Hidro
-  acc <- db_valores[db_valores$campo == "persistenciahidrologica", 2:3]
-  names(acc) <- c("pers_hidro", "pers_hidro_desc")
-  data_sf <- merge(data_sf, acc, all.x = TRUE)
-
-  # Orig. Hidro
-  est <- db_valores[db_valores$campo == "origenhidrografico", 2:3]
-  names(est) <- c("orig_hidro", "orig_hidro_desc")
-  data_sf <- merge(data_sf, est, all.x = TRUE)
+  data_sf <- merge_db_value_desc(
+    data_sf,
+    "persistenciahidrologica",
+    c(
+      "pers_hidro",
+      "pers_hidro_desc"
+    )
+  )
+  data_sf <- merge_db_value_desc(
+    data_sf,
+    "origenhidrografico",
+    c(
+      "orig_hidro",
+      "orig_hidro_desc"
+    )
+  )
 
   # Move the Canary Islands.
   data_sf <- move_can(data_sf, moveCAN)
@@ -204,10 +174,7 @@ esp_get_rivers <- function(
     data_sf <- data_sf[getrows, ]
 
     if (nrow(data_sf) == 0) {
-      cli::cli_alert_warning("No results for {.arg name} {.str {name}}.")
-
-      cli::cli_alert_info("Returning empty {.cls sf} object.")
-      return(data_sf)
+      return(return_empty_name_sf(data_sf, name))
     }
   }
 
@@ -230,62 +197,47 @@ esp_get_wetlands <- function(
   moveCAN = TRUE,
   name = NULL
 ) {
-  init_epsg <- match_arg_pretty(epsg, c("4326", "4258", "3035", "3857"))
+  init_epsg <- validate_epsg(epsg)
 
   url_penin <- paste0(
     "https://github.com/rOpenSpain/mapSpain/raw/sianedata/dist/",
     "se89_3_hidro_rio_a_x.gpkg"
   )
 
-  # Read from the URL when the file is not cached.
-  if (!cache) {
-    msg <- paste0("{.url ", url_penin, "}.")
-    make_msg("info", verbose, "Reading from", msg)
-
-    data_sf_penin <- read_geo_file_sf(url_penin)
-    data_sf <- rbind_fill(list(data_sf_penin))
-  } else {
-    file_local_penin <- download_url(
-      url_penin,
-      cache_dir = cache_dir,
-      subdir = "siane",
-      update_cache = update_cache,
-      verbose = verbose
-    )
-
-    # Read the downloaded files.
-
-    ok_down <- ensure_null(file_local_penin)
-    if (is.null(ok_down)) {
-      return(NULL)
-    }
-
-    data_sf_penin <- read_geo_file_sf(file_local_penin)
-    data_sf_penin
-
-    data_sf <- rbind_fill(list(data_sf_penin))
+  data_sf <- read_siane_files(
+    url_penin,
+    cache = cache,
+    update_cache = update_cache,
+    cache_dir = cache_dir,
+    verbose = verbose
+  )
+  if (is.null(data_sf)) {
+    return(NULL)
   }
 
-  # Add descriptions
-  # Persist. Hidro
-  acc <- db_valores[db_valores$campo == "persistenciahidrologica", 2:3]
-  names(acc) <- c("pers_hidro", "pers_hidro_desc")
-  data_sf <- merge(data_sf, acc, all.x = TRUE)
-
-  # Tipo
-  acc <- db_valores[db_valores$campo == "tiporioa", 2:3]
-  names(acc) <- c("t_rio", "t_rio_desc")
-  data_sf <- merge(data_sf, acc, all.x = TRUE)
+  data_sf <- merge_db_value_desc(
+    data_sf,
+    "persistenciahidrologica",
+    c(
+      "pers_hidro",
+      "pers_hidro_desc"
+    )
+  )
+  data_sf <- merge_db_value_desc(
+    data_sf,
+    "tiporioa",
+    c(
+      "t_rio",
+      "t_rio_desc"
+    )
+  )
 
   name <- ensure_null(name)
   if (!is.null(name)) {
     data_sf <- data_sf[grepl(name, data_sf$rotulo), ]
 
     if (nrow(data_sf) == 0) {
-      cli::cli_alert_warning("No results for {.arg name} {.str {name}}.")
-
-      cli::cli_alert_info("Returning empty {.cls sf} object.")
-      return(data_sf)
+      return(return_empty_name_sf(data_sf, name))
     }
   }
 
@@ -306,18 +258,15 @@ get_river_names <- function(update_cache = FALSE, cache_dir = NULL) {
     "data-raw/rivernames.rda"
   )
 
-  file_local_db <- download_url(
+  db <- download_rds(
     url,
-    cache_dir = cache_dir,
     subdir = "siane",
     update_cache = update_cache,
-    verbose = FALSE
+    cache_dir = cache_dir
   )
-  if (is.null(file_local_db)) {
+  if (is.null(db)) {
     return(NULL)
   }
-
-  db <- readRDS(file_local_db)
 
   tibble::as_tibble(db)
 }

--- a/R/esp-get-landwater.R
+++ b/R/esp-get-landwater.R
@@ -162,9 +162,7 @@ esp_get_rivers <- function(
   river_names <- river_names[, c("id_rio", "NOM_RIO")]
 
   data_sf <- merge(data_sf, river_names, all.x = TRUE)
-  data_sf <- sanitize_sf(data_sf)
-  # Transform to the requested CRS.
-  data_sf <- sf::st_transform(data_sf, as.double(init_epsg))
+  data_sf <- sanitize_transform_sf(data_sf, init_epsg)
 
   name <- ensure_null(name)
   if (!is.null(name)) {
@@ -243,10 +241,7 @@ esp_get_wetlands <- function(
 
   data_sf <- data_sf[order(data_sf$id_ipe), ]
 
-  data_sf <- sanitize_sf(data_sf)
-
-  # Transform to the requested CRS.
-  data_sf <- sf::st_transform(data_sf, as.double(init_epsg))
+  data_sf <- sanitize_transform_sf(data_sf, init_epsg)
   data_sf
 }
 

--- a/R/esp-get-munic-siane.R
+++ b/R/esp-get-munic-siane.R
@@ -72,7 +72,7 @@ esp_get_munic_siane <- function(
   moveCAN = TRUE,
   rawcols = FALSE
 ) {
-  init_epsg <- match_arg_pretty(epsg, c("4326", "4258", "3035", "3857"))
+  init_epsg <- validate_epsg(epsg)
   res <- match_arg_pretty(resolution)
   res <- gsub("6.5", "6m5", res)
 
@@ -90,92 +90,26 @@ esp_get_munic_siane <- function(
     "_admin_muni_a_y.gpkg"
   )
 
-  # Read from the URL when the file is not cached.
-  if (!cache) {
-    msg <- paste0("{.url ", url_penin, "}.")
-    make_msg("info", verbose, "Reading from", msg)
-
-    data_sf_penin <- read_geo_file_sf(url_penin)
-
-    msg <- paste0("{.url ", url_can, "}.")
-    make_msg("info", verbose, "Reading from", msg)
-
-    data_sf_can <- read_geo_file_sf(url_can)
-
-    data_sf <- rbind_fill(list(data_sf_penin, data_sf_can))
-  } else {
-    file_local_penin <- download_url(
-      url_penin,
-      cache_dir = cache_dir,
-      subdir = "siane",
-      update_cache = update_cache,
-      verbose = verbose
-    )
-
-    file_local_can <- download_url(
-      url_can,
-      cache_dir = cache_dir,
-      subdir = "siane",
-      update_cache = update_cache,
-      verbose = verbose
-    )
-
-    # Read the downloaded files.
-    data_sf <- lapply(c(file_local_penin, file_local_can), read_geo_file_sf)
-
-    data_sf <- rbind_fill(data_sf)
-    if (is.null(data_sf)) {
-      return(NULL)
-    }
+  data_sf <- read_siane_files(
+    c(url_penin, url_can),
+    cache = cache,
+    update_cache = update_cache,
+    cache_dir = cache_dir,
+    verbose = verbose
+  )
+  if (is.null(data_sf)) {
+    return(NULL)
   }
   data_sf <- sf::st_transform(data_sf, as.double(init_epsg))
 
   data_sf <- siane_filter_year(data_sf = data_sf, year = year)
-  # Normalize names.
-  data_sf$LAU_CODE <- data_sf$id_ine
-  data_sf$name <- data_sf$rotulo
-  data_sf$cpro <- substr(data_sf$id_ine, 1, 2)
+  data_sf <- add_municipal_metadata(data_sf, "id_ine", "rotulo")
 
-  idprov <- sort(unique(mapSpain::esp_codelist$cpro))
-  data_sf$cmun <- ifelse(
-    substr(data_sf$LAU_CODE, 1, 2) %in% idprov,
-    substr(data_sf$LAU_CODE, 3, 8),
-    NA
-  )
-
-  cod <- unique(mapSpain::esp_codelist[, c(
-    "codauto",
-    "ine.ccaa.name",
-    "cpro",
-    "ine.prov.name"
-  )])
-
-  data_sf <- merge(data_sf, cod, by = "cpro", all.x = TRUE, no.dups = TRUE)
-
-  munic <- ensure_null(munic)
-
-  if (!is.null(munic)) {
-    munic <- paste(munic, collapse = "|")
-    data_sf <- data_sf[grep(munic, data_sf$name, ignore.case = TRUE), ]
-  }
-  region <- ensure_null(region)
-
-  if (!is.null(region)) {
-    tonuts <- convert_to_nuts_prov(region)
-    # Filter to selected provinces.
-    df <- unique(mapSpain::esp_codelist[, c("nuts3.code", "cpro")])
-    df <- df[df$nuts3.code %in% tonuts, "cpro"]
-    toprov <- unique(df$cpro)
-    data_sf <- data_sf[data_sf$cpro %in% toprov, ]
-  }
+  data_sf <- filter_by_name_pattern(data_sf, munic, "name")
+  data_sf <- filter_by_cpro_region(data_sf, region)
 
   if (nrow(data_sf) == 0) {
-    cli::cli_alert_warning(paste0(
-      "The combination of {.arg region}, {.arg munic} or both does not ",
-      "return any results."
-    ))
-    cli::cli_alert_info("Returning empty {.cls sf} object.")
-    return(data_sf)
+    return(return_empty_combination_sf(data_sf, "munic"))
   }
 
   # Move the Canary Islands.

--- a/R/esp-get-munic-siane.R
+++ b/R/esp-get-munic-siane.R
@@ -1,15 +1,9 @@
 #' Municipalities of Spain from SIANE
 #'
-#' @encoding UTF-8
-#' @family political
-#' @family siane
-#' @family municipalities
 #' @inheritParams esp_get_ccaa_siane
 #' @inheritParams esp_get_munic
 #' @inherit esp_get_munic description details return
 #' @inherit esp_get_ccaa_siane source
-#' @export
-#'
 #' @note
 #'
 #' Although \CRANpkg{mapSpain} supplies cartographically suitable datasets,
@@ -21,6 +15,12 @@
 #'   contornos municipales de España –LAU2boundaries4Spain–* \[Data set\].
 #'   Zenodo. \doi{10.5281/zenodo.15345101},
 #'   <https://www.uv.es/goerlich/Ivie/LAU2boundaries4Spain.html>.
+#'
+#' @family political
+#' @family siane
+#' @family municipalities
+#' @encoding UTF-8
+#' @export
 #'
 #' @examplesIf esp_check_access()
 #' \donttest{

--- a/R/esp-get-munic.R
+++ b/R/esp-get-munic.R
@@ -3,13 +3,13 @@
 #' @description
 #' This dataset shows boundaries of municipalities in Spain.
 #'
-#' @encoding UTF-8
-#' @family political
-#' @family municipalities
-#' @family gisco
-#' @inheritParams esp_get_nuts
-#' @inherit giscoR::gisco_get_lau
-#' @export
+#' @details
+#' When using `region` you can use and mix names and NUTS codes (levels 1, 2 or
+#' 3), ISO codes (corresponding to level 2 or 3) or `"cpro"`
+#' (see [esp_codelist]).
+#'
+#' When calling a higher level (province, Autonomous Community or NUTS1), all
+#' the municipalities of that level will be added.
 #'
 #' @param year Year character string or number. Release year of the file. See
 #'   [giscoR::gisco_get_lau()] and [giscoR::gisco_get_communes()] for valid
@@ -19,15 +19,20 @@
 #'   municipalities.
 #' @param cache `r lifecycle::badge("deprecated")`. This argument is
 #'   deprecated, the dataset will always be downloaded to the `cache_dir`.
+#' @inheritParams esp_get_nuts
+#' @inherit giscoR::gisco_get_lau return source
+#'
+#' @note
+#' Please check the download and usage provisions on
+#' [giscoR::gisco_attributions()].
+#'
 #' @seealso [giscoR::gisco_get_lau()], [giscoR::gisco_get_communes()].
 #'
-#' @details
-#' When using `region` you can use and mix names and NUTS codes (levels 1, 2 or
-#' 3), ISO codes (corresponding to level 2 or 3) or `"cpro"`
-#' (see [esp_codelist]).
-#'
-#' When calling a higher level (province, CCAA or NUTS1), all the municipalities
-#' of that level will be added.
+#' @family political
+#' @family municipalities
+#' @family gisco
+#' @encoding UTF-8
+#' @export
 #'
 #' @examplesIf esp_check_access()
 #' \donttest{
@@ -98,7 +103,7 @@ esp_get_munic <- function(
   moveCAN = TRUE,
   ext = "gpkg"
 ) {
-  # Dispatch everything to giscoR except EPSG, that is specific
+  # Dispatch to giscoR and handle the package-specific EPSG value locally.
   init_epsg <- validate_epsg(epsg, c("4258", "4326", "3035", "3857"))
   gisco_epsg <- ifelse(epsg == "4258", "4326", init_epsg)
   cache_dir <- create_cache_dir(cache_dir)
@@ -131,7 +136,7 @@ esp_get_munic <- function(
   if (is.null(data_sf)) {
     return(NULL)
   }
-  # Some files does not have crs (??)
+  # Some files do not provide a CRS.
   file_epsg <- ensure_null(sf::st_crs(data_sf)$wkt)
 
   if (is.null(file_epsg)) {

--- a/R/esp-get-munic.R
+++ b/R/esp-get-munic.R
@@ -99,7 +99,7 @@ esp_get_munic <- function(
   ext = "gpkg"
 ) {
   # Dispatch everything to giscoR except EPSG, that is specific
-  init_epsg <- match_arg_pretty(epsg, c("4258", "4326", "3035", "3857"))
+  init_epsg <- validate_epsg(epsg, c("4258", "4326", "3035", "3857"))
   gisco_epsg <- ifelse(epsg == "4258", "4326", init_epsg)
   cache_dir <- create_cache_dir(cache_dir)
 
@@ -138,32 +138,17 @@ esp_get_munic <- function(
     data_sf <- sf::st_set_crs(data_sf, sf::st_crs(as.numeric(gisco_epsg)))
   }
 
-  # Id management
   id_col <- intersect(c("GISCO_ID", "LAU_ID", "NSI_CODE"), names(data_sf))[1]
-  data_sf$LAU_CODE <- gsub("\\D+", "", data_sf[[id_col]])
-
-  # Normalize names.
   id_name <- intersect(c("LAU_NAME", "COMM_NAME", "SABE_NAME"), names(data_sf))[
     1
   ]
-  data_sf$name <- data_sf[[id_name]]
 
-  data_sf$cpro <- substr(data_sf$LAU_CODE, 1, 2)
-  data_sf$cmun <- substr(data_sf$LAU_CODE, 3, 8)
-
-  add_codes <- unique(mapSpain::esp_codelist[, c(
-    "codauto",
-    "ine.ccaa.name",
-    "cpro",
-    "ine.prov.name"
-  )])
-
-  data_sf <- merge(
+  data_sf <- add_municipal_metadata(
     data_sf,
-    add_codes,
-    by = "cpro",
-    all.x = TRUE,
-    no.dups = TRUE
+    id_col,
+    id_name,
+    clean_id = TRUE,
+    validate_cpro = FALSE
   )
 
   init_nm <- names(data_sf)
@@ -182,30 +167,11 @@ esp_get_munic <- function(
   # Filter munics
   data_sf <- sf::st_transform(data_sf, as.double(init_epsg))
 
-  munic <- ensure_null(munic)
-
-  if (!is.null(munic)) {
-    munic <- paste(munic, collapse = "|")
-    data_sf <- data_sf[grep(munic, data_sf$name, ignore.case = TRUE), ]
-  }
-  region <- ensure_null(region)
-
-  if (!is.null(region)) {
-    tonuts <- convert_to_nuts_prov(region)
-    # Filter to selected provinces.
-    df <- unique(mapSpain::esp_codelist[, c("nuts3.code", "cpro")])
-    df <- df[df$nuts3.code %in% tonuts, "cpro"]
-    toprov <- unique(df$cpro)
-    data_sf <- data_sf[data_sf$cpro %in% toprov, ]
-  }
+  data_sf <- filter_by_name_pattern(data_sf, munic, "name")
+  data_sf <- filter_by_cpro_region(data_sf, region)
 
   if (nrow(data_sf) == 0) {
-    cli::cli_alert_warning(paste0(
-      "The combination of {.arg region}, {.arg munic} or both does not ",
-      "return any results."
-    ))
-    cli::cli_alert_info("Returning empty {.cls sf} object.")
-    return(data_sf)
+    return(return_empty_combination_sf(data_sf, "munic"))
   }
 
   # Move the Canary Islands.

--- a/R/esp-get-nuts.R
+++ b/R/esp-get-nuts.R
@@ -119,7 +119,7 @@ esp_get_nuts <- function(
   ext = "gpkg"
 ) {
   # Dispatch everything to gisco_get_nuts except EPSG, that is specific
-  epsg <- match_arg_pretty(epsg, c("4258", "4326", "3035", "3857"))
+  epsg <- validate_epsg(epsg, c("4258", "4326", "3035", "3857"))
   gisco_epsg <- ifelse(epsg == "4258", "4326", epsg)
   cache_dir <- create_cache_dir(cache_dir)
   spatialtype <- match_arg_pretty(spatialtype)
@@ -185,9 +185,10 @@ esp_get_nuts <- function(
     data_sf <- data_sf[data_sf$NUTS_ID %in% nuts_id, ]
 
     if (nrow(data_sf) == 0) {
-      cli::cli_alert_warning(paste0("No matches for {.arg region = {region}}."))
-      cli::cli_alert_info("Returning empty {.cls sf} object.")
-      return(data_sf)
+      return(return_empty_sf(
+        data_sf,
+        "No matches for {.arg region = {region}}."
+      ))
     }
   }
 

--- a/R/esp-get-nuts.R
+++ b/R/esp-get-nuts.R
@@ -15,15 +15,19 @@
 #' Also, there is a NUTS 0 level, which usually corresponds to the national
 #' boundaries.
 #'
-#' @encoding UTF-8
-#' @family political
-#' @family nuts
-#' @family gisco
-#' @inheritParams giscoR::gisco_get_nuts
-#' @inherit giscoR::gisco_get_nuts
-#' @export
+#' @details
+#' The NUTS nomenclature is a hierarchical classification of statistical
+#' regions and subdivides the EU economic territory into regions of three
+#' different levels (NUTS 1, 2 and 3, moving respectively from larger to smaller
+#' territorial units). NUTS 1 is the most aggregated level. An additional
+#' country level (NUTS 0) is also available for countries where the nation at
+#' statistical level does not coincide with the administrative boundaries.
 #'
-#' @seealso [giscoR::gisco_get_nuts()], [esp_dict_region_code()].
+#' The NUTS classification has been officially established through Commission
+#' Delegated Regulation 2019/1755. A non-official NUTS-like classification has
+#' been defined for the EFTA countries, candidate countries and potential
+#' candidates based on a bilateral agreement between Eurostat and the respective
+#' statistical agencies.
 #'
 #' @param year Year character string or number. Release year of the file. See
 #'   [giscoR::gisco_get_nuts()] for valid values.
@@ -52,6 +56,21 @@
 #'   **Displacing the Canary Islands** in [esp_move_can()].
 #' @param ext Character. Extension of the file (default `"gpkg"`). See
 #'   [giscoR::gisco_get_nuts()].
+#'
+#' @inheritParams giscoR::gisco_get_nuts
+#' @inherit giscoR::gisco_get_nuts return source
+#'
+#' @note
+#' Please check the download and usage provisions on
+#' [giscoR::gisco_attributions()].
+#'
+#' @seealso [giscoR::gisco_get_nuts()], [esp_dict_region_code()].
+#'
+#' @family political
+#' @family nuts
+#' @family gisco
+#' @encoding UTF-8
+#' @export
 #'
 #' @examples
 #' nuts1 <- esp_get_nuts(nuts_level = 1, moveCAN = TRUE)
@@ -118,7 +137,7 @@ esp_get_nuts <- function(
   moveCAN = TRUE,
   ext = "gpkg"
 ) {
-  # Dispatch everything to gisco_get_nuts except EPSG, that is specific
+  # Dispatch to gisco_get_nuts and handle the package-specific EPSG value.
   epsg <- validate_epsg(epsg, c("4258", "4326", "3035", "3857"))
   gisco_epsg <- ifelse(epsg == "4258", "4326", epsg)
   cache_dir <- create_cache_dir(cache_dir)

--- a/R/esp-get-prov-siane.R
+++ b/R/esp-get-prov-siane.R
@@ -28,7 +28,7 @@ esp_get_prov_siane <- function(
   moveCAN = TRUE,
   rawcols = FALSE
 ) {
-  init_epsg <- match_arg_pretty(epsg, c("4326", "4258", "3035", "3857"))
+  init_epsg <- validate_epsg(epsg)
   res <- match_arg_pretty(resolution)
   res <- gsub("6.5", "6m5", res)
 
@@ -46,43 +46,15 @@ esp_get_prov_siane <- function(
     "_admin_prov_a_y.gpkg"
   )
 
-  # Read from the URL when the file is not cached.
-  if (!cache) {
-    msg <- paste0("{.url ", url_penin, "}.")
-    make_msg("info", verbose, "Reading from", msg)
-
-    data_sf_penin <- read_geo_file_sf(url_penin)
-
-    msg <- paste0("{.url ", url_can, "}.")
-    make_msg("info", verbose, "Reading from", msg)
-
-    data_sf_can <- read_geo_file_sf(url_can)
-
-    data_sf <- rbind_fill(list(data_sf_penin, data_sf_can))
-  } else {
-    file_local_penin <- download_url(
-      url_penin,
-      cache_dir = cache_dir,
-      subdir = "siane",
-      update_cache = update_cache,
-      verbose = verbose
-    )
-
-    file_local_can <- download_url(
-      url_can,
-      cache_dir = cache_dir,
-      subdir = "siane",
-      update_cache = update_cache,
-      verbose = verbose
-    )
-
-    # Read the downloaded files.
-    data_sf <- lapply(c(file_local_penin, file_local_can), read_geo_file_sf)
-
-    data_sf <- rbind_fill(data_sf)
-    if (is.null(data_sf)) {
-      return(NULL)
-    }
+  data_sf <- read_siane_files(
+    c(url_penin, url_can),
+    cache = cache,
+    update_cache = update_cache,
+    cache_dir = cache_dir,
+    verbose = verbose
+  )
+  if (is.null(data_sf)) {
+    return(NULL)
   }
 
   data_sf <- siane_filter_year(data_sf = data_sf, year = year)
@@ -90,30 +62,14 @@ esp_get_prov_siane <- function(
   initcols <- colnames(sf::st_drop_geometry(data_sf))
   data_sf$cpro <- data_sf$id_prov
 
-  prov <- ensure_null(prov)
-  if (!is.null(prov)) {
-    tonuts <- convert_to_nuts_prov(prov)
-
-    df <- unique(mapSpain::esp_codelist[, c("nuts3.code", "cpro")])
-    df <- df[df$nuts3.code %in% tonuts, "cpro"]
-    toprov <- unique(df$cpro)
-    data_sf <- data_sf[data_sf$cpro %in% toprov, ]
-  }
+  data_sf <- filter_by_cpro_region(data_sf, prov)
 
   # Get province metadata.
   df <- get_prov_codes_df()
   data_sf <- merge(data_sf, df, all.x = TRUE)
 
   # Add NUTS2 metadata.
-  dfnuts <- mapSpain::esp_codelist
-  dfnuts <- unique(dfnuts[, c(
-    "cpro",
-    "nuts2.code",
-    "nuts2.name",
-    "nuts1.code",
-    "nuts1.name"
-  )])
-  data_sf <- merge(data_sf, dfnuts, all.x = TRUE)
+  data_sf <- merge(data_sf, get_prov_nuts_codes_df(), all.x = TRUE)
 
   # Move the Canary Islands.
   data_sf <- move_can(data_sf, moveCAN)
@@ -141,34 +97,4 @@ esp_get_prov_siane <- function(
 
   data_sf <- sanitize_sf(data_sf)
   data_sf
-}
-
-get_prov_codes_df <- function() {
-  getnames <- c(
-    "codauto",
-    "cpro",
-    "iso2.prov.code",
-    "nuts.prov.code",
-    "ine.prov.name",
-    "iso2.prov.name.es",
-    "iso2.prov.name.ca",
-    "iso2.prov.name.ga",
-    "iso2.prov.name.eu",
-    "cldr.prov.name.en",
-    "cldr.prov.name.es",
-    "cldr.prov.name.ca",
-    "cldr.prov.name.ga",
-    "cldr.prov.name.eu",
-    "prov.shortname.en",
-    "prov.shortname.es",
-    "prov.shortname.ca",
-    "prov.shortname.ga",
-    "prov.shortname.eu"
-  )
-
-  df_prov <- mapSpain::esp_codelist
-  df_prov <- df_prov[, getnames]
-  df_end <- unique(df_prov)
-  df_end <- df_end[order(df_end$codauto), ]
-  df_end
 }

--- a/R/esp-get-prov-siane.R
+++ b/R/esp-get-prov-siane.R
@@ -1,12 +1,12 @@
 #' Provinces of Spain from SIANE
 #'
-#' @encoding UTF-8
-#' @family political
-#' @family siane
 #' @inheritParams esp_get_ccaa_siane
 #' @inheritParams esp_get_prov
 #' @inherit esp_get_prov description details
 #' @inherit esp_get_ccaa_siane source return
+#' @family political
+#' @family siane
+#' @encoding UTF-8
 #' @export
 #'
 #' @examplesIf esp_check_access()

--- a/R/esp-get-prov.R
+++ b/R/esp-get-prov.R
@@ -107,19 +107,7 @@ esp_get_prov <- function(prov = NULL, moveCAN = TRUE, ...) {
   data_sf <- data_sf[, "cpro"]
   data_sf <- data_sf[order(data_sf$cpro), ]
 
-  # Merge island geometries by province code.
-  res_cpros <- unique(data_sf$cpro)
-  binded_sf <- lapply(res_cpros, function(x) {
-    the_geom <- data_sf[data_sf$cpro == x, ]
-    if (nrow(the_geom) == 1) {
-      return(the_geom)
-    }
-    get_g <- sf::st_geometry(data_sf[data_sf$cpro == x, ])
-    g <- sf::st_union(get_g)
-    sf::st_sf(cpro = x, geometry = g)
-  })
-
-  data_sf <- rbind_fill(binded_sf)
+  data_sf <- union_sf_by(data_sf, "cpro")
 
   # Get province metadata.
   df <- get_prov_codes_df()
@@ -127,17 +115,7 @@ esp_get_prov <- function(prov = NULL, moveCAN = TRUE, ...) {
   data_sf <- merge(data_sf, df, all.x = TRUE)
 
   # Add NUTS2 metadata.
-  dfnuts <- mapSpain::esp_codelist
-  dfnuts <- dfnuts[, c(
-    "cpro",
-    "nuts2.code",
-    "nuts2.name",
-    "nuts1.code",
-    "nuts1.name"
-  )]
-  dfnuts <- unique(dfnuts)
-
-  data_sf <- merge(data_sf, dfnuts, all.x = TRUE)
+  data_sf <- merge(data_sf, get_prov_nuts_codes_df(), all.x = TRUE)
 
   data_sf <- data_sf[, c(
     colnames(df),

--- a/R/esp-get-prov.R
+++ b/R/esp-get-prov.R
@@ -5,20 +5,6 @@
 #' [provinces of Spain](https://en.wikipedia.org/wiki/Provinces_of_Spain)
 #' at a specified scale.
 #'
-#' @encoding UTF-8
-#' @family political
-#' @family gisco
-#' @inheritParams esp_get_nuts
-#' @inheritDotParams esp_get_nuts -nuts_level -region
-#' @inherit esp_get_nuts
-#' @export
-#'
-#' @param prov A vector of names, codes or both for provinces, or `NULL` to get
-#'   all the provinces. See **Details**.
-#'
-#' @inheritParams esp_get_nuts
-#' @inheritDotParams esp_get_nuts -nuts_level -region
-#'
 #' @details
 #' When using `prov` you can use and mix names and NUTS codes (levels 1, 2 or
 #' 3), ISO codes (corresponding to level 2 or 3) or "cpro" (see
@@ -28,6 +14,19 @@
 #'
 #' When calling a higher level (Autonomous Community or NUTS1), all the
 #' provinces of that level will be added.
+#'
+#' @param prov A vector of names, codes or both for provinces, or `NULL` to get
+#'   all the provinces. See **Details**.
+#'
+#' @inheritParams esp_get_nuts
+#' @inheritDotParams esp_get_nuts -nuts_level -region
+#'
+#' @inherit esp_get_nuts
+#'
+#' @family political
+#' @family gisco
+#' @encoding UTF-8
+#' @export
 #'
 #' @examples
 #' prov <- esp_get_prov()

--- a/R/esp-get-railway.R
+++ b/R/esp-get-railway.R
@@ -55,7 +55,7 @@ esp_get_railway <- function(
   verbose = FALSE,
   spatialtype = c("line", "point")
 ) {
-  init_epsg <- match_arg_pretty(epsg, c("4326", "4258", "3035", "3857"))
+  init_epsg <- validate_epsg(epsg)
   sp <- match_arg_pretty(spatialtype)
 
   if (sp == "point") {
@@ -85,49 +85,49 @@ esp_get_railway <- function(
     "dist/se89_3_vias_ffcc_l_x.gpkg"
   )
 
-  # Read from the URL when the file is not cached.
-  if (!cache) {
-    msg <- paste0("{.url ", url, "}.")
-    make_msg("info", verbose, "Reading from", msg)
-
-    data_sf <- read_geo_file_sf(url)
-  } else {
-    file_local <- download_url(
-      url,
-      cache_dir = cache_dir,
-      subdir = "siane",
-      update_cache = update_cache,
-      verbose = verbose
-    )
-
-    # Read the downloaded files.
-    data_sf <- lapply(file_local, read_geo_file_sf)
-
-    data_sf <- rbind_fill(data_sf)
-    if (is.null(data_sf)) {
-      return(NULL)
-    }
+  data_sf <- read_siane_files(
+    url,
+    cache = cache,
+    update_cache = update_cache,
+    cache_dir = cache_dir,
+    verbose = verbose
+  )
+  if (is.null(data_sf)) {
+    return(NULL)
   }
 
-  # Add descriptions for railway type.
-  acc <- db_valores[db_valores$campo == "tipoffcc", 2:3]
-  names(acc) <- c("t_ffcc", "t_ffcc_desc")
-  data_sf <- merge(data_sf, acc, all.x = TRUE)
-
-  # Add physical status descriptions.
-  est <- db_valores[db_valores$campo == "estadofisico", 2:3]
-  names(est) <- c("estado_fis", "estado_fis_desc")
-  data_sf <- merge(data_sf, est, all.x = TRUE)
-
-  # Add track gauge descriptions.
-  acc <- db_valores[db_valores$campo == "anchovia", 2:3]
-  names(acc) <- c("ancho_via", "ancho_via_desc")
-  data_sf <- merge(data_sf, acc, all.x = TRUE)
-
-  # Add track count descriptions.
-  tip <- db_valores[db_valores$campo == "numerovias", 2:3]
-  names(tip) <- c("num_vias", "num_vias_desc")
-  data_sf <- merge(data_sf, tip, all.x = TRUE)
+  data_sf <- merge_db_value_desc(
+    data_sf,
+    "tipoffcc",
+    c(
+      "t_ffcc",
+      "t_ffcc_desc"
+    )
+  )
+  data_sf <- merge_db_value_desc(
+    data_sf,
+    "estadofisico",
+    c(
+      "estado_fis",
+      "estado_fis_desc"
+    )
+  )
+  data_sf <- merge_db_value_desc(
+    data_sf,
+    "anchovia",
+    c(
+      "ancho_via",
+      "ancho_via_desc"
+    )
+  )
+  data_sf <- merge_db_value_desc(
+    data_sf,
+    "numerovias",
+    c(
+      "num_vias",
+      "num_vias_desc"
+    )
+  )
 
   data_sf <- sanitize_sf(data_sf)
   data_sf <- data_sf[order(data_sf$t_ffcc, data_sf$ancho_via), ]

--- a/R/esp-get-railway.R
+++ b/R/esp-get-railway.R
@@ -129,8 +129,7 @@ esp_get_railway <- function(
     )
   )
 
-  data_sf <- sanitize_sf(data_sf)
   data_sf <- data_sf[order(data_sf$t_ffcc, data_sf$ancho_via), ]
-  data_sf <- sf::st_transform(data_sf, as.double(init_epsg))
+  data_sf <- sanitize_transform_sf(data_sf, init_epsg)
   data_sf
 }

--- a/R/esp-get-railway.R
+++ b/R/esp-get-railway.R
@@ -4,16 +4,16 @@
 #' Loads a [`sf`][sf::st_sf] `LINESTRING` or `POINT` object representing the
 #' nodes and railway lines of Spain.
 #'
-#' @rdname esp_get_railway
-#' @encoding UTF-8
-#' @family infrastructure
-#' @inheritParams esp_get_ccaa_siane
-#' @inherit esp_get_ccaa_siane return source
-#' @export
-#'
 #' @param year Ignored.
 #' @param spatialtype `r lifecycle::badge("deprecated")` character string.
 #'   Use [mapSpain::esp_get_stations()] instead of `"point"` for stations.
+#'
+#' @inheritParams esp_get_ccaa_siane
+#' @inherit esp_get_ccaa_siane return source
+#' @family infrastructure
+#' @encoding UTF-8
+#' @rdname esp_get_railway
+#' @export
 #'
 #' @examplesIf esp_check_access()
 #' \donttest{

--- a/R/esp-get-roads.R
+++ b/R/esp-get-roads.R
@@ -94,9 +94,6 @@ esp_get_roads <- function(
 
   data_sf <- data_sf[order(data_sf$t_ctra, data_sf$orden, data_sf$rotulo), ]
 
-  data_sf <- sanitize_sf(data_sf)
-
-  # Transform to the requested CRS.
-  data_sf <- sf::st_transform(data_sf, as.double(init_epsg))
+  data_sf <- sanitize_transform_sf(data_sf, init_epsg)
   data_sf
 }

--- a/R/esp-get-roads.R
+++ b/R/esp-get-roads.R
@@ -3,11 +3,11 @@
 #' @description
 #' Object representing the main roads of Spain.
 #'
-#' @encoding UTF-8
-#' @family infrastructure
 #' @inheritParams esp_get_railway
 #' @inheritParams esp_get_ccaa_siane
-#' @inherit esp_get_railway
+#' @inherit esp_get_railway return source
+#' @family infrastructure
+#' @encoding UTF-8
 #' @export
 #'
 #' @examplesIf esp_check_access()

--- a/R/esp-get-roads.R
+++ b/R/esp-get-roads.R
@@ -38,7 +38,7 @@ esp_get_roads <- function(
   verbose = FALSE,
   moveCAN = TRUE
 ) {
-  init_epsg <- match_arg_pretty(epsg, c("4326", "4258", "3035", "3857"))
+  init_epsg <- validate_epsg(epsg)
 
   url_penin <- paste0(
     "https://github.com/rOpenSpain/mapSpain/raw/sianedata/dist/",
@@ -50,72 +50,43 @@ esp_get_roads <- function(
     "se89_3_vias_ctra_l_y.gpkg"
   )
 
-  # Read from the URL when the file is not cached.
-  if (!cache) {
-    msg <- paste0("{.url ", url_penin, "}.")
-    make_msg("info", verbose, "Reading from", msg)
-
-    data_sf_penin <- read_geo_file_sf(url_penin)
-    data_sf_penin$codauto <- "XX"
-
-    msg <- paste0("{.url ", url_can, "}.")
-    make_msg("info", verbose, "Reading from", msg)
-
-    data_sf_can <- read_geo_file_sf(url_can)
-    data_sf_can$codauto <- "05"
-
-    data_sf <- rbind_fill(list(data_sf_penin, data_sf_can))
-  } else {
-    file_local_penin <- download_url(
-      url_penin,
-      cache_dir = cache_dir,
-      subdir = "siane",
-      update_cache = update_cache,
-      verbose = verbose
-    )
-
-    file_local_can <- download_url(
-      url_can,
-      cache_dir = cache_dir,
-      subdir = "siane",
-      update_cache = update_cache,
-      verbose = verbose
-    )
-
-    # Read the downloaded files.
-    ok_down <- ensure_null(c(file_local_penin, file_local_can))
-    if (is.null(ok_down)) {
-      return(NULL)
-    }
-
-    data_sf_penin <- read_geo_file_sf(file_local_penin)
-    data_sf_penin$codauto <- "XX"
-
-    data_sf_can <- read_geo_file_sf(file_local_can)
-    data_sf_can$codauto <- "05"
-
-    data_sf <- rbind_fill(list(data_sf_penin, data_sf_can))
+  data_sf <- read_siane_files(
+    c(url_penin, url_can),
+    cache = cache,
+    update_cache = update_cache,
+    cache_dir = cache_dir,
+    verbose = verbose,
+    codauto = c("XX", "05")
+  )
+  if (is.null(data_sf)) {
+    return(NULL)
   }
 
-  # Add road type descriptions.
-  tip <- db_valores[db_valores$campo == "tipocarretera", 2:3]
-  names(tip) <- c("t_ctra", "t_ctra_desc")
-  data_sf <- merge(data_sf, tip, all.x = TRUE)
-
-  # Add physical status descriptions.
-  est <- db_valores[db_valores$campo == "estadofisico", 2:3]
-  names(est) <- c("estado_fis", "estado_fis_desc")
-  data_sf <- merge(data_sf, est, all.x = TRUE)
-
-  # Add road order descriptions.
-  ord <- db_valores[db_valores$campo == "orden", 2:3]
-  names(ord) <- c("orden", "orden_desc")
-  data_sf <- merge(data_sf, ord, all.x = TRUE)
-
-  # Add access descriptions.
-  acc <- db_valores[db_valores$campo == "acceso", 2:3]
-  names(acc) <- c("acceso", "acceso_desc")
-  data_sf <- merge(data_sf, acc, all.x = TRUE)
+  data_sf <- merge_db_value_desc(
+    data_sf,
+    "tipocarretera",
+    c(
+      "t_ctra",
+      "t_ctra_desc"
+    )
+  )
+  data_sf <- merge_db_value_desc(
+    data_sf,
+    "estadofisico",
+    c(
+      "estado_fis",
+      "estado_fis_desc"
+    )
+  )
+  data_sf <- merge_db_value_desc(data_sf, "orden", c("orden", "orden_desc"))
+  data_sf <- merge_db_value_desc(
+    data_sf,
+    "acceso",
+    c(
+      "acceso",
+      "acceso_desc"
+    )
+  )
 
   # Move the Canary Islands.
   data_sf <- move_can(data_sf, moveCAN)

--- a/R/esp-get-simpl.R
+++ b/R/esp-get-simpl.R
@@ -73,18 +73,16 @@ esp_get_simpl_prov <- function(
     "ine_prov_simplified.gpkg"
   )
 
-  file_local <- download_url(
+  data_sf <- download_and_read_geo_file(
     url,
-    cache_dir = cache_dir,
     subdir = "ine",
     update_cache = update_cache,
+    cache_dir = cache_dir,
     verbose = verbose
   )
-  if (is.null(file_local)) {
+  if (is.null(data_sf)) {
     return(NULL)
   }
-
-  data_sf <- read_geo_file_sf(file_local)
 
   # Order features by Autonomous Community and province.
   data_sf <- data_sf[order(data_sf$codauto, data_sf$cpro), ]
@@ -95,13 +93,7 @@ esp_get_simpl_prov <- function(
   if (is.null(prov)) {
     return(data_sf)
   }
-  region <- convert_to_nuts_prov(prov)
-
-  dfcpro <- mapSpain::esp_codelist
-  dfcpro <- unique(dfcpro[, c("nuts3.code", "cpro")])
-  cprocodes <- unique(dfcpro[dfcpro$nuts3.code %in% region, ]$cpro)
-
-  data_sf <- data_sf[data_sf$cpro %in% cprocodes, ]
+  data_sf <- filter_by_cpro_region(data_sf, prov)
 
   data_sf
 }
@@ -121,18 +113,16 @@ esp_get_simpl_ccaa <- function(
     "ine_ccaa_simplified.gpkg"
   )
 
-  file_local <- download_url(
+  data_sf <- download_and_read_geo_file(
     url,
-    cache_dir = cache_dir,
     subdir = "ine",
     update_cache = update_cache,
+    cache_dir = cache_dir,
     verbose = verbose
   )
-  if (is.null(file_local)) {
+  if (is.null(data_sf)) {
     return(NULL)
   }
-
-  data_sf <- read_geo_file_sf(file_local)
 
   # Order features by Autonomous Community.
   data_sf <- data_sf[order(data_sf$codauto), ]
@@ -143,12 +133,7 @@ esp_get_simpl_ccaa <- function(
   if (is.null(ccaa)) {
     return(data_sf)
   }
-  nuts_id <- convert_to_nuts_ccaa(ccaa)
-  dfcodauto <- mapSpain::esp_codelist
-  dfcodauto <- unique(dfcodauto[, c("nuts2.code", "codauto")])
-  dfcodauto <- unique(dfcodauto[dfcodauto$nuts2.code %in% nuts_id, ]$codauto)
-
-  data_sf <- data_sf[data_sf$codauto %in% dfcodauto, ]
+  data_sf <- filter_by_codauto_region(data_sf, ccaa)
 
   data_sf
 }

--- a/R/esp-get-simpl.R
+++ b/R/esp-get-simpl.R
@@ -6,25 +6,6 @@
 #' communities of Spain, as provided by the **INE** (Instituto Nacional de
 #' Estadistica).
 #'
-#' @rdname esp_get_simpl
-#' @name esp_get_simpl
-#'
-#' @encoding UTF-8
-#' @family political
-#' @inheritParams esp_get_prov
-#' @inheritParams esp_get_ccaa
-#' @inheritParams esp_get_nuts
-#' @inherit esp_get_nuts return
-#' @export
-#'
-#' @param prov,ccaa Character. A vector of names, codes or both for provinces
-#'   and Autonomous Communities, or `NULL` to get all the data. See
-#'   **Details**.
-#'
-#' @seealso [`esp_get_gridmap`][esp_get_gridmap].
-#'
-#' @source INE: PC_Axis files
-#'
 #' @details
 #'
 #' Results are provided **without CRS**, as provided by the source.
@@ -36,6 +17,25 @@
 #' `esp_get_prov("Andalucia")`) all the corresponding units of that level are
 #' provided (in this case, all the provinces of Andalusia).
 #'
+#' @param prov,ccaa Character. A vector of names, codes or both for provinces
+#'   and Autonomous Communities, or `NULL` to get all the data. See
+#'   **Details**.
+#'
+#' @inheritParams esp_get_prov
+#' @inheritParams esp_get_ccaa
+#' @inheritParams esp_get_nuts
+#' @inherit esp_get_nuts return
+#' @source INE: PC_Axis files
+#'
+#' @seealso [`esp_get_gridmap`][esp_get_gridmap].
+#'
+#' @family political
+#' @encoding UTF-8
+#' @rdname esp_get_simpl
+#' @name esp_get_simpl
+#'
+#' @export
+#'
 #' @examplesIf esp_check_access()
 #' \donttest{
 #' prov_simp <- esp_get_simpl_prov()
@@ -44,16 +44,16 @@
 #'
 #' ggplot(prov_simp) +
 #'   geom_sf(aes(fill = ine.ccaa.name)) +
-#'   labs(fill = "CCAA")
+#'   labs(fill = "Autonomous Communities")
 #'
-#' # Provinces of a single CCAA.
+#' # Provinces of a single Autonomous Community.
 #'
 #' and_simple <- esp_get_simpl_prov("Andalucia")
 #'
 #' ggplot(and_simple) +
 #'   geom_sf()
 #'
-#' # CCAAs.
+#' # Autonomous Communities.
 #'
 #' ccaa_simp <- esp_get_simpl_ccaa()
 #'

--- a/R/esp-get-spain-siane.R
+++ b/R/esp-get-spain-siane.R
@@ -3,12 +3,12 @@
 #' @description
 #' Returns the boundaries of Spain as a single [`sf`][sf::st_sf] `POLYGON`.
 #'
-#' @encoding UTF-8
-#' @family political
-#' @family siane
 #' @inheritParams esp_get_ccaa_siane
 #' @inheritDotParams esp_get_ccaa_siane -ccaa -rawcols
 #' @inherit esp_get_ccaa_siane source return
+#' @family political
+#' @family siane
+#' @encoding UTF-8
 #' @export
 #'
 #' @examplesIf esp_check_access()

--- a/R/esp-get-spain.R
+++ b/R/esp-get-spain.R
@@ -4,25 +4,24 @@
 #' Returns the boundaries of Spain as a single [`sf`][sf::st_sf] `POLYGON` at a
 #' specified scale.
 #'
-#' @encoding UTF-8
-#' @family political
-#' @family nuts
-#' @family gisco
-#' @inheritParams giscoR::gisco_get_nuts
-#' @inherit esp_get_nuts
-#' @export
-#'
-#' @rdname esp_get_spain
-#' @name esp_get_spain
-#'
-#' @return A [`sf`][sf::st_sf] `POLYGON` object.
-#'
 #' @details
 #' Dataset derived from NUTS data provided by GISCO. Check [esp_get_nuts()] for
 #' details.
 #'
 #' @inheritParams esp_get_nuts
 #' @inheritDotParams esp_get_nuts -nuts_level -region -spatialtype
+#'
+#' @inherit esp_get_nuts
+#' @return A [`sf`][sf::st_sf] `POLYGON` object.
+#'
+#' @family political
+#' @family nuts
+#' @family gisco
+#' @encoding UTF-8
+#' @rdname esp_get_spain
+#' @name esp_get_spain
+#'
+#' @export
 #'
 #' @examplesIf esp_check_access()
 #' \donttest{
@@ -76,7 +75,7 @@ esp_get_spain <- function(moveCAN = TRUE, ...) {
   data_sf
 }
 
-#' @export
 #' @rdname esp_get_spain
+#' @export
 #' @usage NULL
 esp_get_country <- esp_get_spain

--- a/R/esp-get-stations.R
+++ b/R/esp-get-stations.R
@@ -8,38 +8,23 @@ esp_get_stations <- function(
   cache_dir = NULL,
   verbose = FALSE
 ) {
-  init_epsg <- match_arg_pretty(epsg, c("4326", "4258", "3035", "3857"))
+  init_epsg <- validate_epsg(epsg)
 
   url <- paste0(
     "https://github.com/rOpenSpain/mapSpain/raw/sianedata/",
     "dist/se89_3_vias_ffcc_p_x.gpkg"
   )
 
-  # Read from the URL when the file is not cached.
-  if (!cache) {
-    msg <- paste0("{.url ", url, "}.")
-    make_msg("info", verbose, "Reading from", msg)
-
-    data_sf <- read_geo_file_sf(url)
-  } else {
-    file_local <- download_url(
-      url,
-      cache_dir = cache_dir,
-      subdir = "siane",
-      update_cache = update_cache,
-      verbose = verbose
-    )
-
-    # Read the downloaded files.
-    data_sf <- lapply(file_local, read_geo_file_sf)
-
-    data_sf <- rbind_fill(data_sf)
-    if (is.null(data_sf)) {
-      return(NULL)
-    }
+  data_sf <- read_siane_files(
+    url,
+    cache = cache,
+    update_cache = update_cache,
+    cache_dir = cache_dir,
+    verbose = verbose
+  )
+  if (is.null(data_sf)) {
+    return(NULL)
   }
-
-  data_sf <- sf::st_transform(data_sf, as.double(init_epsg))
 
   data_sf <- sf::st_transform(data_sf, as.double(init_epsg))
   data_sf

--- a/R/esp-get-stations.R
+++ b/R/esp-get-stations.R
@@ -26,6 +26,6 @@ esp_get_stations <- function(
     return(NULL)
   }
 
-  data_sf <- sf::st_transform(data_sf, as.double(init_epsg))
+  data_sf <- sanitize_transform_sf(data_sf, init_epsg)
   data_sf
 }

--- a/R/esp-get-tiles.R
+++ b/R/esp-get-tiles.R
@@ -8,52 +8,6 @@
 #' [leaflet-providersESP](https://dieghernan.github.io/leaflet-providersESP/)
 #' **`r leaf_providers_esp_v`**.
 #'
-#' @encoding UTF-8
-#' @family images
-#' @seealso [terra::rast()], [esp_tiles_providers]
-#'
-#' @rdname esp_get_tiles
-#' @name esp_get_tiles
-#' @order 1
-#'
-#' @return
-#' A `SpatRaster` with 3 (RGB) or 4 (RGBA) layers, depending on
-#' the provider. See [terra::rast()].
-#'
-#' @source
-#' <https://dieghernan.github.io/leaflet-providersESP/>, a plugin for
-#' \CRANpkg{leaflet}, **`r leaf_providers_esp_v`**.
-#'
-#' @export
-#'
-#' @param x An [`sf`][sf::st_sf] or [`sfc`][sf::st_sfc] object.
-#'
-#' @param type This argument can be either:
-#'   - The name of one of the pre-defined providers (see
-#'     [esp_tiles_providers]).
-#'   - A list with two named elements `id` and `q` with your own arguments. See
-#'     [esp_make_provider()] and examples.
-#' @param zoom Character string or number. Only valid for WMTS providers, zoom
-#'   level to be downloaded. If `NULL`, it is determined automatically. If set,
-#'   it overrides `zoommin`. If a single `sf` `POINT` and `zoom = NULL`, the
-#'   function sets a zoom level of 18. See **Details**.
-#' @param zoommin Character string or number. Delta on default `zoom`.
-#'   The default value is designed to download fewer tiles than you probably
-#'   want. Use `1` or `2` to increase the resolution.
-#' @param crop Logical. If `TRUE`, the results will be cropped to the specified
-#'   `x` extent. If `x` is an [`sf`][sf::st_sf] object with one `POINT`,
-#'   `crop` is set to `FALSE`. See [terra::crop()].
-#' @param res Character string or number. Only valid for WMS providers.
-#'   Resolution (in pixels) of the final tile.
-#' @param bbox_expand Number. Expansion percentage of the bounding box of `x`.
-#' @param transparent Logical. Provides transparent background, if supported.
-#' @param mask Logical. `TRUE` if the result should be masked to `x`. See
-#'   [terra::mask()].
-#' @param options A named list containing additional options to pass to the
-#'   query.
-#'
-#' @inheritParams esp_get_nuts
-#'
 #' @details
 #' Zoom levels are described on the
 #' [OpenStreetMap wiki](https://wiki.openstreetmap.org/wiki/Zoom_levels):
@@ -89,6 +43,52 @@
 #' try projecting first `x`:
 #'
 #' `x <- sf::st_transform(x, 3857)`
+#'
+#' @param x An [`sf`][sf::st_sf] or [`sfc`][sf::st_sfc] object.
+#'
+#' @param type This argument can be either:
+#'   - The name of one of the pre-defined providers (see
+#'     [esp_tiles_providers]).
+#'   - A list with two named elements `id` and `q` with your own arguments. See
+#'     [esp_make_provider()] and examples.
+#' @param zoom Character string or number. Only valid for WMTS providers, zoom
+#'   level to be downloaded. If `NULL`, it is determined automatically. If set,
+#'   it overrides `zoommin`. If a single `sf` `POINT` and `zoom = NULL`, the
+#'   function sets a zoom level of 18. See **Details**.
+#' @param zoommin Character string or number. Delta on default `zoom`.
+#'   The default value is designed to download fewer tiles than you probably
+#'   want. Use `1` or `2` to increase the resolution.
+#' @param crop Logical. If `TRUE`, the results will be cropped to the specified
+#'   `x` extent. If `x` is an [`sf`][sf::st_sf] object with one `POINT`,
+#'   `crop` is set to `FALSE`. See [terra::crop()].
+#' @param res Character string or number. Only valid for WMS providers.
+#'   Resolution (in pixels) of the final tile.
+#' @param bbox_expand Number. Expansion percentage of the bounding box of `x`.
+#' @param transparent Logical. Provides transparent background, if supported.
+#' @param mask Logical. `TRUE` if the result should be masked to `x`. See
+#'   [terra::mask()].
+#' @param options A named list containing additional options to pass to the
+#'   query.
+#'
+#' @inheritParams esp_get_nuts
+#'
+#' @return
+#' A `SpatRaster` with 3 (RGB) or 4 (RGBA) layers, depending on
+#' the provider. See [terra::rast()].
+#'
+#' @source
+#' <https://dieghernan.github.io/leaflet-providersESP/>, a plugin for
+#' \CRANpkg{leaflet}, **`r leaf_providers_esp_v`**.
+#'
+#' @seealso [terra::rast()], [esp_tiles_providers]
+#'
+#' @family images
+#' @encoding UTF-8
+#' @rdname esp_get_tiles
+#' @name esp_get_tiles
+#' @order 1
+#'
+#' @export
 #'
 #' @examplesIf esp_check_access()
 #' \dontrun{
@@ -389,7 +389,7 @@ get_wms_tile <- function(bbox, prov_list, update_cache, cache_dir, verbose) {
 
   r <- terra::rast(file_local, noflip = TRUE)
 
-  # Extension and crs
+  # Set extent and CRS.
   terra::ext(r) <- terra::ext(terra::vect(bbox))
   crs_tile <- get_tile_crs(prov_list)
   terra::crs(r) <- crs_tile
@@ -544,7 +544,7 @@ set_wmts_tile_extent_crs <- function(r, xtile, ytile, ztile, prov_list) {
   r
 }
 
-#' @export
 #' @rdname esp_get_tiles
+#' @export
 #' @usage NULL
 esp_getTiles <- esp_get_tiles

--- a/R/esp-get-tiles.R
+++ b/R/esp-get-tiles.R
@@ -167,41 +167,84 @@ esp_get_tiles <- function(
   }
 
   geom <- sf::st_geometry(x)
+  provider <- prepare_tile_provider(type, options, res)
+  prov_list <- provider$prov_list
+  prov_type <- provider$prov_type
 
-  # Validate
+  tile_geom <- prepare_tile_geometry(geom, zoom, crop, prov_type)
+  geom <- tile_geom$geom
+  zoom <- tile_geom$zoom
+  crop <- tile_geom$crop
+
+  geom <- sf::st_transform(geom, provider$prov_crs)
+  bbox <- get_tile_bbox(geom, bbox_expand = bbox_expand, prov_type = prov_type)
+
+  tile_map <- get_tile_map(
+    bbox,
+    prov_list,
+    prov_type,
+    zoom,
+    zoommin,
+    update_cache,
+    cache_dir,
+    verbose
+  )
+  if (is.null(tile_map)) {
+    return(NULL)
+  }
+
+  finish_tile_map(
+    tile_map,
+    x,
+    bbox,
+    prov_list,
+    crop,
+    mask,
+    transparent,
+    verbose
+  )
+}
+
+prepare_tile_provider <- function(type, options, res) {
   prov_list <- validate_provider(type)
-
-  # Add options
   prov_list <- modify_provider_list(prov_list, options)
 
-  # Extension
-  prov_ext <- get_tile_ext(prov_list)
-  valid_ext <- c("png", "jpeg", "jpg", "tiff", "geotiff")
+  validate_tile_ext(get_tile_ext(prov_list))
 
-  prov_ext <- match_arg_pretty(prov_ext, valid_ext)
-
-  # Get crs of Tile
-  prov_crs <- get_tile_crs(prov_list)
-
-  # Type of provider
   prov_type <- guess_provider_type(prov_list)
-
-  # On WMS add here the target resolution
   if (prov_type == "WMS") {
     prov_list$width <- res
     prov_list$height <- res
   }
 
-  # Mix info of provider and geom
+  list(
+    prov_list = prov_list,
+    prov_type = prov_type,
+    prov_crs = get_tile_crs(prov_list)
+  )
+}
+
+validate_tile_ext <- function(ext) {
+  valid_ext <- c("png", "jpeg", "jpg", "tiff", "geotiff")
+  if (ext %in% valid_ext) {
+    return(ext)
+  }
+
+  cli::cli_abort(paste0(
+    "The requested file extension should be one of ",
+    "{.str png}, {.str jpeg}, {.str jpg}, {.str tiff} or {.str geotiff}, ",
+    "not {.str {ext}}."
+  ))
+}
+
+prepare_tile_geometry <- function(geom, zoom, crop, prov_type) {
   zoom <- ensure_null(zoom)
 
-  # Single point would be buffered
   if (all(length(geom) == 1, sf::st_geometry_type(geom) == "POINT")) {
     geom_buff <- sf::st_buffer(sf::st_transform(geom, 3857), 50)
     geom <- sf::st_transform(geom_buff, sf::st_crs(geom))
-
-    # Modify some defaults
     crop <- FALSE
+
     if (is.null(zoom)) {
       zoom <- 18
       make_msg(
@@ -212,43 +255,78 @@ esp_get_tiles <- function(
     }
   }
 
-  geom <- sf::st_transform(geom, prov_crs)
-  bbox <- get_tile_bbox(geom, bbox_expand = bbox_expand, prov_type = prov_type)
+  list(geom = geom, zoom = zoom, crop = crop)
+}
 
+get_tile_map <- function(
+  bbox,
+  prov_list,
+  prov_type,
+  zoom,
+  zoommin,
+  update_cache,
+  cache_dir,
+  verbose
+) {
   if (prov_type == "WMS") {
-    tile_map <- get_wms_tile(bbox, prov_list, update_cache, cache_dir, verbose)
-  } else {
-    tile_map <- get_wmts_tile(
-      bbox,
-      prov_list,
-      zoom,
-      zoommin,
-      update_cache,
-      cache_dir,
-      verbose
-    )
-  }
-  if (is.null(tile_map)) {
-    return(NULL)
+    return(get_wms_tile(bbox, prov_list, update_cache, cache_dir, verbose))
   }
 
-  # Colorize when needed, for example with Catastro.
-  if (all(terra::nlyr(tile_map) == 1)) {
-    tile_map <- terra::colorize(tile_map, to = "rgb", alpha = TRUE)
-  }
+  get_wmts_tile(
+    bbox,
+    prov_list,
+    zoom,
+    zoommin,
+    update_cache,
+    cache_dir,
+    verbose
+  )
+}
+
+finish_tile_map <- function(
+  tile_map,
+  x,
+  bbox,
+  prov_list,
+  crop,
+  mask,
+  transparent,
+  verbose
+) {
+  tile_map <- colorize_single_layer_tile(tile_map)
 
   x_terra <- terra::vect(x)
   bbox_terra <- terra::vect(bbox)
 
-  # Finish
   tile_map <- terra::clamp(tile_map, lower = 0, upper = 255, values = TRUE)
-  # reproject tile_map if needed
   if (terra::crs(x_terra) != terra::crs(tile_map)) {
     tile_map <- terra::project(tile_map, x_terra, mask = mask)
   }
 
-  # Attribution
+  show_tile_attribution(prov_list, verbose)
 
+  if (crop) {
+    bbox_terra <- terra::project(bbox_terra, terra::crs(tile_map))
+    tile_map <- terra::crop(tile_map, bbox_terra)
+  }
+
+  if (mask) {
+    tile_map <- terra::mask(tile_map, x_terra)
+  }
+
+  tile_map <- apply_tile_transparency(tile_map, transparent)
+  name_tile_bands(tile_map)
+}
+
+colorize_single_layer_tile <- function(tile_map) {
+  if (all(terra::nlyr(tile_map) == 1)) {
+    return(terra::colorize(tile_map, to = "rgb", alpha = TRUE))
+  }
+
+  tile_map
+}
+
+show_tile_attribution <- function(prov_list, verbose) {
   attrib <- ensure_null(prov_list$attribution)
   make_msg(
     "info",
@@ -256,31 +334,22 @@ esp_get_tiles <- function(
     "{.emph Data and map tiles sources}:",
     paste0("{.strong ", attrib, "}.")
   )
+}
 
-  # crop management
-  if (crop) {
-    bbox_terra <- terra::project(bbox_terra, terra::crs(tile_map))
-
-    tile_map <- terra::crop(tile_map, bbox_terra)
-  }
-
-  # mask
-  if (mask) {
-    tile_map <- terra::mask(tile_map, x_terra)
-  }
-
-  # Transparency
+apply_tile_transparency <- function(tile_map, transparent) {
   if (all(transparent, terra::nlyr(tile_map) == 4)) {
     tomask <- terra::subset(tile_map, 4)
     tomask[tomask == 0] <- NA
-
     tile_map <- terra::mask(tile_map, tomask)
   }
   if (!transparent) {
     tile_map <- terra::subset(tile_map, 1:3)
   }
 
-  # Names and attributes
+  tile_map
+}
+
+name_tile_bands <- function(tile_map) {
   nm <- c("red", "green", "blue", "alpha")
   nl <- seq_len(terra::nlyr(tile_map))
   names(tile_map) <- nm[nl]
@@ -336,116 +405,23 @@ get_wmts_tile <- function(
   cache_dir,
   verbose
 ) {
-  # Need bbox in 4326
-  bbox_4326 <- sf::st_transform(bbox, 4326)
-  bbox_4326 <- sf::st_bbox(bbox_4326)
-
-  # Zoom management
-  zoom <- ensure_null(as.numeric(zoom))
-  zoommin <- ensure_null(as.numeric(zoommin))
-  min_zoom <- ensure_null(as.numeric(prov_list$min_zoom))
-  tile_grid <- bbox_tile_query(bbox_4326)
-
-  # Need autozoom
-  if (is.null(zoom)) {
-    zoom <- min(tile_grid[tile_grid$total_tiles %in% seq(4, 12), ]$zoom) +
-      zoommin
-    make_msg("info", verbose, paste0("Autozoom level: {.val ", zoom, "}."))
-  }
-
-  # Check provider
-  if (all(!is.null(min_zoom), min_zoom > zoom)) {
-    make_msg(
-      "info",
-      TRUE,
-      paste0(
-        "Minimum {.arg zoom} supported by this provider is ",
-        "{.val ",
-        min_zoom,
-        "}. Increasing {.arg zoom} (it was {.val ",
-        zoom,
-        "})."
-      )
-    )
-    zoom <- max(zoom, min_zoom)
-  }
-
-  # Composing grid
-  # get tile list
+  bbox_4326 <- wmts_bbox_4326(bbox)
+  zoom <- resolve_wmts_zoom(bbox_4326, prov_list, zoom, zoommin, verbose)
   tile_numbers <- bbox_to_tile_grid(bbox = bbox_4326, zoom = as.numeric(zoom))
   tile_numbers_df <- tile_numbers$tiles
 
-  # Prepare query
-  prov_ext <- get_tile_ext(prov_list)
-  prov_folder <- prov_list$id
+  tile_query <- prepare_wmts_tile_query(prov_list)
 
-  q <- prov_list$q
-  remove_fields <- c("id", "q", "min_zoom", "attribution")
-  rest <- prov_list[!names(prov_list) %in% remove_fields]
-  if (length(rest) > 0) {
-    q <- paste0(q, paste0(names(rest), "=", rest, collapse = "&"))
-  }
-
-  # Perform query
-  tile_iter <- seq_len(nrow(tile_numbers_df))
-
-  tile_list <- lapply(tile_iter, function(i) {
-    # x and y.
-    xtile <- tile_numbers_df[i, ]$x
-    ytile <- tile_numbers_df[i, ]$y
-    ztile <- zoom
-    q_tile <- q
-
-    # Replace in q
-    q_tile <- gsub(
-      pattern = "{x}",
-      replacement = xtile,
-      x = q_tile,
-      fixed = TRUE
+  tile_list <- lapply(seq_len(nrow(tile_numbers_df)), function(i) {
+    download_wmts_tile(
+      tile_numbers_df[i, ],
+      zoom,
+      tile_query,
+      prov_list,
+      update_cache,
+      cache_dir,
+      verbose
     )
-    q_tile <- gsub(
-      pattern = "{y}",
-      replacement = ytile,
-      x = q_tile,
-      fixed = TRUE
-    )
-    q_tile <- gsub(
-      pattern = "{z}",
-      replacement = ztile,
-      x = q_tile,
-      fixed = TRUE
-    )
-    file_name <- paste0("tile_", ztile, "_", xtile, "_", ytile, ".", prov_ext)
-    file_local <- download_url(
-      url = q_tile,
-      name = file_name,
-      cache_dir = cache_dir,
-      subdir = prov_folder,
-      update_cache = update_cache,
-      verbose = verbose
-    )
-
-    file_local <- ensure_null(file_local)
-    if (is.null(file_local)) {
-      return(NULL)
-    }
-
-    r <- terra::rast(file_local, noflip = TRUE)
-
-    # Colorize before merging when needed, for example with MapBox.
-    if (all(terra::nlyr(r) == 1)) {
-      r <- terra::colorize(r, to = "rgb", alpha = TRUE)
-    }
-
-    # Extension and crs
-    ext_tile <- tile_bbox(xtile, ytile, ztile)
-    ext_tile <- sf::st_as_sfc(ext_tile)
-    ext_tile <- terra::vect(ext_tile)
-
-    terra::ext(r) <- terra::ext(ext_tile)
-    crs_tile <- get_tile_crs(prov_list)
-    terra::crs(r) <- crs_tile
-    r
   })
 
   if (all(lengths(tile_list) == 0)) {
@@ -464,6 +440,108 @@ get_wmts_tile <- function(
   r_all <- terra::merge(r_all)
 
   r_all
+}
+
+wmts_bbox_4326 <- function(bbox) {
+  bbox_4326 <- sf::st_transform(bbox, 4326)
+  sf::st_bbox(bbox_4326)
+}
+
+resolve_wmts_zoom <- function(bbox_4326, prov_list, zoom, zoommin, verbose) {
+  zoom <- ensure_null(as.numeric(zoom))
+  zoommin <- ensure_null(as.numeric(zoommin))
+  min_zoom <- ensure_null(as.numeric(prov_list$min_zoom))
+
+  if (is.null(zoom)) {
+    tile_grid <- bbox_tile_query(bbox_4326)
+    zoom <- min(tile_grid[tile_grid$total_tiles %in% seq(4, 12), ]$zoom) +
+      zoommin
+    make_msg("info", verbose, paste0("Autozoom level: {.val ", zoom, "}."))
+  }
+
+  if (all(!is.null(min_zoom), min_zoom > zoom)) {
+    make_msg(
+      "info",
+      TRUE,
+      paste0(
+        "Minimum {.arg zoom} supported by this provider is ",
+        "{.val ",
+        min_zoom,
+        "}. Increasing {.arg zoom} (it was {.val ",
+        zoom,
+        "})."
+      )
+    )
+    zoom <- max(zoom, min_zoom)
+  }
+
+  zoom
+}
+
+prepare_wmts_tile_query <- function(prov_list) {
+  q <- prov_list$q
+  remove_fields <- c("id", "q", "min_zoom", "attribution")
+  rest <- prov_list[!names(prov_list) %in% remove_fields]
+  if (length(rest) > 0) {
+    q <- paste0(q, paste0(names(rest), "=", rest, collapse = "&"))
+  }
+
+  list(
+    q = q,
+    ext = get_tile_ext(prov_list),
+    folder = prov_list$id
+  )
+}
+
+download_wmts_tile <- function(
+  tile,
+  zoom,
+  tile_query,
+  prov_list,
+  update_cache,
+  cache_dir,
+  verbose
+) {
+  xtile <- tile$x
+  ytile <- tile$y
+  ztile <- zoom
+
+  q_tile <- build_wmts_tile_url(tile_query$q, xtile, ytile, ztile)
+  file_name <- paste0("tile_", ztile, "_", xtile, "_", ytile, ".")
+  file_name <- paste0(file_name, tile_query$ext)
+  file_local <- download_url(
+    url = q_tile,
+    name = file_name,
+    cache_dir = cache_dir,
+    subdir = tile_query$folder,
+    update_cache = update_cache,
+    verbose = verbose
+  )
+
+  file_local <- ensure_null(file_local)
+  if (is.null(file_local)) {
+    return(NULL)
+  }
+
+  r <- terra::rast(file_local, noflip = TRUE)
+  r <- colorize_single_layer_tile(r)
+  set_wmts_tile_extent_crs(r, xtile, ytile, ztile, prov_list)
+}
+
+build_wmts_tile_url <- function(q, xtile, ytile, ztile) {
+  q <- gsub("{x}", xtile, q, fixed = TRUE)
+  q <- gsub("{y}", ytile, q, fixed = TRUE)
+  gsub("{z}", ztile, q, fixed = TRUE)
+}
+
+set_wmts_tile_extent_crs <- function(r, xtile, ytile, ztile, prov_list) {
+  ext_tile <- tile_bbox(xtile, ytile, ztile)
+  ext_tile <- sf::st_as_sfc(ext_tile)
+  ext_tile <- terra::vect(ext_tile)
+
+  terra::ext(r) <- terra::ext(ext_tile)
+  terra::crs(r) <- get_tile_crs(prov_list)
+  r
 }
 
 #' @export

--- a/R/esp-make-provider.R
+++ b/R/esp-make-provider.R
@@ -3,26 +3,6 @@
 #' @description
 #' Helper function for [esp_get_tiles()] that helps to create a custom provider.
 #'
-#' @encoding UTF-8
-#' @family images
-#' @seealso [esp_get_tiles()].
-#'
-#' For a list of potential providers from Spain check
-#' [IDEE Directory](https://www.idee.es/segun-tipo-de-servicio).
-#'
-#' @return
-#' A named list with two elements `id` and `q`.
-#'
-#' @export
-#'
-#' @param id An identifier for the user. It will be used for identifying
-#'   cached tiles.
-#' @param q The base URL of the service.
-#' @param service The type of tile service, either `"WMS"` or `"WMTS"`.
-#' @param layers The name of the layer to retrieve.
-#' @param ... Additional arguments to the query, like `version`, `format`,
-#'   `crs/srs` and `style`, depending on the capabilities of the service.
-#'
 #' @details
 #' This function is meant to work with services provided as of the
 #' [OGC Standard](https://www.ogc.org/standards/wms/).
@@ -32,6 +12,26 @@
 #'   provided.
 #' - Currently, on **WMTS** requests only services with
 #'   `tilematrixset=GoogleMapsCompatible` are supported.
+#'
+#' @param id An identifier for the user. It will be used for identifying
+#'   cached tiles.
+#' @param q The base URL of the service.
+#' @param service The type of tile service, either `"WMS"` or `"WMTS"`.
+#' @param layers The name of the layer to retrieve.
+#' @param ... Additional arguments to the query, like `version`, `format`,
+#'   `crs/srs` and `style`, depending on the capabilities of the service.
+#'
+#' @return
+#' A named list with two elements `id` and `q`.
+#'
+#' @seealso [esp_get_tiles()].
+#'
+#' For a list of potential providers from Spain check
+#' [IDEE Directory](https://www.idee.es/segun-tipo-de-servicio).
+#'
+#' @family images
+#' @encoding UTF-8
+#' @export
 #'
 #' @examplesIf esp_check_access()
 #' \dontrun{
@@ -88,7 +88,7 @@ esp_make_provider <- function(id, q, service, layers, ...) {
   # Modify
   end <- modifyList(def_params, dots)
 
-  # Here adjust crs values
+  # Adjust CRS/SRS parameter names.
 
   if (end$service == "WMS") {
     if (all(!is.null(end$version), end$version < "1.3.0")) {

--- a/R/esp-move-can.R
+++ b/R/esp-move-can.R
@@ -5,14 +5,6 @@
 #' representing a location in the Canary Islands) to align it with the objects
 #' provided by [`sf`][sf::st_sf] with the option `moveCAN = TRUE`.
 #'
-#' @param x An [`sf`][sf::st_sf] object. It can be an `sf` or `sfc` object.
-#' @param moveCAN A logical `TRUE/FALSE` or a vector of coordinates
-#'   `c(lat, lon)`. It places the Canary Islands close to Spain's mainland.
-#'   Initial position can be adjusted using the vector of coordinates.
-#'
-#' @return A [`sf`][sf::st_sf] object of the same class and same CRS as `x`
-#' but displaced accordingly.
-#'
 #' @details
 #' This is a helper function that intends to ease the representation of objects
 #' located in the Canary Islands that have been obtained from other sources
@@ -26,8 +18,16 @@
 #' [addProviderEspTiles()]) this option should be set to `FALSE` in order to
 #' get the actual coordinates, instead of the modified ones.
 #'
-#' @encoding UTF-8
+#' @param x An [`sf`][sf::st_sf] object. It can be an `sf` or `sfc` object.
+#' @param moveCAN A logical `TRUE/FALSE` or a vector of coordinates
+#'   `c(lat, lon)`. It places the Canary Islands close to Spain's mainland.
+#'   Initial position can be adjusted using the vector of coordinates.
+#'
+#' @return A [`sf`][sf::st_sf] object of the same class and same CRS as `x`
+#' but displaced accordingly.
+#'
 #' @family can_helpers
+#' @encoding UTF-8
 #' @export
 #'
 #' @examples
@@ -106,13 +106,13 @@ esp_move_can <- function(x, moveCAN = TRUE) {
     df <- sf::st_drop_geometry(data_3857)
     can <- sf::st_sf(df, geometry = geom_mov, crs = 3857)
 
-    # Regenerate CRS
+    # Regenerate the CRS.
     x_out <- sf::st_transform(can, sf::st_crs(x))
 
     if (is_sfc) {
       x_out <- sf::st_geometry(x_out)
     } else {
-      # Rename sf col
+      # Rename the sf column.
       sf::st_geometry(x_out) <- attr(x, "sf_column")
     }
   } else {

--- a/R/esp-move-can.R
+++ b/R/esp-move-can.R
@@ -85,10 +85,7 @@ esp_move_can <- function(x, moveCAN = TRUE) {
     return(x)
   }
 
-  moving <- FALSE
-  moving <- isTRUE(moveCAN) | length(moveCAN) > 1
-
-  if (moving) {
+  if (is_moving_can(moveCAN)) {
     offset <- c(550000, 920000)
 
     if (length(moveCAN) > 1) {
@@ -130,7 +127,6 @@ move_can <- function(data_sf, moveCAN = TRUE) {
     return(data_sf)
   }
   # Checks
-  moving <- FALSE
   prepare_can <- data_sf
   if ("codauto" %in% names(data_sf)) {
     prepare_can$is_can <- prepare_can$codauto == "05"
@@ -139,7 +135,7 @@ move_can <- function(data_sf, moveCAN = TRUE) {
     prepare_can$is_can <- grepl("^ES7", data_sf$NUTS_ID)
   }
 
-  moving <- (isTRUE(moveCAN) | length(moveCAN) >= 2) & any(prepare_can$is_can)
+  moving <- is_moving_can(moveCAN) & any(prepare_can$is_can)
 
   if (moving) {
     penin <- prepare_can[!prepare_can$is_can, ]

--- a/R/esp-siane-bulk-download.R
+++ b/R/esp-siane-bulk-download.R
@@ -4,17 +4,17 @@
 #' Download zipped data from SIANE to the [`cache_dir`][esp_set_cache_dir()]
 #' and extract the relevant ones.
 #'
-#' @encoding UTF-8
-#' @family political
-#' @family siane
 #' @inheritParams esp_get_ccaa_siane
 #' @inheritParams esp_get_prov
 #' @inherit esp_get_ccaa_siane source return
-#' @export
-#'
 #' @return
 #' A (invisible) character vector with the full path of the files extracted.
 #' See **Examples**.
+#' @family political
+#' @family siane
+#' @encoding UTF-8
+#' @export
+#'
 #' @examplesIf esp_check_access()
 #' tmp <- file.path(tempdir(), "testexample")
 #' dest_files <- esp_siane_bulk_download(cache_dir = tmp)

--- a/R/utils-convert-names.R
+++ b/R/utils-convert-names.R
@@ -4,32 +4,18 @@
 #'
 #' @noRd
 convert_to_nuts <- function(region) {
-  # Remove duplicates and normalize empty values.
-  clean_region <- unique(ensure_null(region))
+  clean_region <- clean_region_arg(region)
   if (is.null(clean_region)) {
     cli::cli_alert_warning(
       "Empty {.arg region}. No NUTS codes found, returning NULL."
     )
     return(NULL)
   }
-  clean_region <- region[!is.na(clean_region)]
 
-  # Detect code type for conversion: NUTS, ISO2 or free text.
-  code_type <- rep("text", length(clean_region))
-
-  is_iso <- grepl("^ES-", clean_region)
-  is_nuts <- clean_region %in% get_all_nuts_codes()
-
-  code_type[is_iso] <- "iso2"
-  code_type[is_nuts] <- "nuts"
-
-  # Perform conversions.
-  n_codes <- seq_along(clean_region)
-
-  # Initialize output vector.
+  code_type <- detect_region_code_type(clean_region, iso = TRUE)
   nuts_id <- rep(NA, length(clean_region))
 
-  for (i in n_codes) {
+  for (i in seq_along(clean_region)) {
     code <- clean_region[i]
     type <- code_type[i]
     if (type == "nuts") {
@@ -55,7 +41,7 @@ convert_to_nuts <- function(region) {
     )
   }
 
-  sort(nuts_id[!is.na(nuts_id)])
+  sort(unique(nuts_id[!is.na(nuts_id)]))
 }
 
 #' Transform regions to NUTS codes for CCAA (NUTS 2)
@@ -65,28 +51,15 @@ convert_to_nuts <- function(region) {
 #'
 #' @noRd
 convert_to_nuts_ccaa <- function(region) {
-  # Remove duplicates and normalize empty values.
-  clean_region <- unique(ensure_null(region))
+  clean_region <- clean_region_arg(region)
   if (is.null(clean_region)) {
     return(NULL)
   }
-  clean_region <- region[!is.na(clean_region)]
 
-  # Detect code type for conversion: NUTS, ISO2 or free text.
-  code_type <- rep("text", length(clean_region))
-  is_codauto <- grepl("^[[:digit:]]", region)
-  is_nuts <- region %in% get_all_nuts_codes()
-
-  code_type[is_codauto] <- "codauto"
-  code_type[is_nuts] <- "nuts"
-
-  # Perform conversions.
-  n_codes <- seq_along(clean_region)
-
-  # Initialize output vector.
+  code_type <- detect_region_code_type(clean_region, digit_type = "codauto")
   ccaa_id <- rep(NA, length(clean_region))
 
-  for (i in n_codes) {
+  for (i in seq_along(clean_region)) {
     code <- clean_region[i]
     type <- code_type[i]
 
@@ -142,7 +115,7 @@ convert_to_nuts_ccaa <- function(region) {
     ccaa_id <- unique(c(ccaa_id, nutslev1))
   }
 
-  end <- sort(ccaa_id[!is.na(ccaa_id)])
+  end <- sort(unique(ccaa_id[!is.na(ccaa_id)]))
   end
 }
 
@@ -153,12 +126,10 @@ convert_to_nuts_ccaa <- function(region) {
 #'
 #' @noRd
 convert_to_nuts_prov <- function(region) {
-  # Remove duplicates and normalize empty values.
-  clean_region <- unique(ensure_null(region))
+  clean_region <- clean_region_arg(region)
   if (is.null(clean_region)) {
     return(NULL)
   }
-  clean_region <- region[!is.na(clean_region)]
 
   # Handle island cases where NUTS3 and province codes diverge.
   clean_region[clean_region == "ES-GC"] <- "35"
@@ -167,24 +138,15 @@ convert_to_nuts_prov <- function(region) {
   clean_region[clean_region == "ES-IB"] <- "ES53"
   clean_region[clean_region == "07"] <- "ES53"
 
-  # Detect code type for conversion: cpro, NUTS, ISO2 or free text.
-  code_type <- rep("text", length(clean_region))
-  is_cpro <- grepl("^[[:digit:]]", clean_region)
-  is_iso <- grepl("^ES-", clean_region)
-  is_nuts <- clean_region %in% get_all_nuts_codes()
-
-  code_type[is_cpro] <- "cpro"
-  code_type[is_iso] <- "iso2"
-  code_type[is_nuts] <- "nuts"
-
-  # Perform conversions.
-  n_codes <- seq_along(clean_region)
-
-  # Initialize output vector.
+  code_type <- detect_region_code_type(
+    clean_region,
+    digit_type = "cpro",
+    iso = TRUE
+  )
   nuts_cpros <- clean_region
 
   # Convert text to cpro to check Canary Islands and Balearic Islands.
-  for (i in n_codes) {
+  for (i in seq_along(clean_region)) {
     code <- nuts_cpros[i]
     type <- code_type[i]
 
@@ -211,21 +173,16 @@ convert_to_nuts_prov <- function(region) {
     }
   }
 
-  # Reassess code types after island-specific normalization.
-  code_type <- rep("text", length(nuts_cpros))
-
-  is_cpro <- grepl("^[[:digit:]]", nuts_cpros)
-  is_iso <- grepl("^ES-", nuts_cpros)
-  is_nuts <- nuts_cpros %in% get_all_nuts_codes()
-
-  code_type[is_cpro] <- "cpro"
-  code_type[is_iso] <- "iso2"
-  code_type[is_nuts] <- "nuts"
+  code_type <- detect_region_code_type(
+    nuts_cpros,
+    digit_type = "cpro",
+    iso = TRUE
+  )
 
   # Build the province-to-NUTS lookup table.
   cpro_to_nuts <- get_prov_to_nuts_df()
 
-  for (i in n_codes) {
+  for (i in seq_along(nuts_cpros)) {
     code <- nuts_cpros[i]
     type <- code_type[i]
 
@@ -311,6 +268,29 @@ convert_to_nuts_prov <- function(region) {
   }
 
   nuts_id
+}
+
+clean_region_arg <- function(region) {
+  clean_region <- unique(ensure_null(region))
+  if (is.null(clean_region)) {
+    return(NULL)
+  }
+
+  clean_region[!is.na(clean_region)]
+}
+
+detect_region_code_type <- function(region, digit_type = NULL, iso = FALSE) {
+  code_type <- rep("text", length(region))
+
+  if (!is.null(digit_type)) {
+    code_type[grepl("^[[:digit:]]", region)] <- digit_type
+  }
+  if (iso) {
+    code_type[grepl("^ES-", region)] <- "iso2"
+  }
+
+  code_type[region %in% get_all_nuts_codes()] <- "nuts"
+  code_type
 }
 
 #' Build a lookup table from province codes (cpro) to NUTS codes

--- a/R/utils-convert-names.R
+++ b/R/utils-convert-names.R
@@ -29,16 +29,12 @@ convert_to_nuts <- function(region) {
     )
   }
   if (all(is.na(nuts_id))) {
-    cli::cli_alert_warning(
-      "No Spanish NUTS codes found for {.str {clean_region}}."
-    )
+    warn_no_spanish_codes("NUTS", clean_region)
     return(NULL)
   }
 
   if (anyNA(nuts_id)) {
-    cli::cli_alert_warning(
-      "No Spanish NUTS codes found for {.str {clean_region[is.na(nuts_id)]}}."
-    )
+    warn_no_spanish_codes("NUTS", clean_region[is.na(nuts_id)])
   }
 
   sort(unique(nuts_id[!is.na(nuts_id)]))
@@ -83,7 +79,7 @@ convert_to_nuts_ccaa <- function(region) {
   }
 
   if (all(is.na(ccaa_id))) {
-    cli::cli_abort("No Spanish CCAA codes found for {.str {clean_region}}.")
+    abort_no_spanish_codes("CCAA", clean_region)
   }
 
   # Map Ceuta and Melilla to their CCAA codes.
@@ -93,14 +89,11 @@ convert_to_nuts_ccaa <- function(region) {
   novalid <- is.na(ccaa_id) | nchar(ccaa_id) > 4
 
   if (all(novalid)) {
-    cli::cli_abort("No Spanish CCAA codes found for {.str {clean_region}}.")
+    abort_no_spanish_codes("CCAA", clean_region)
   }
 
   if (any(novalid)) {
-    cli::cli_alert_warning(paste0(
-      "No Spanish CCAA codes found for ",
-      "{.str {clean_region[novalid]}}."
-    ))
+    warn_no_spanish_codes("CCAA", clean_region[novalid])
   }
 
   ccaa_id <- ccaa_id[!novalid]
@@ -206,7 +199,7 @@ convert_to_nuts_prov <- function(region) {
   }
 
   if (all(is.na(nuts_cpros))) {
-    cli::cli_abort("No Spanish province codes found for {.str {clean_region}}.")
+    abort_no_spanish_codes("province", clean_region)
   }
 
   # Remove island NUTS3 codes that do not correspond to provinces.
@@ -220,13 +213,11 @@ convert_to_nuts_prov <- function(region) {
 
   nomatch <- nuts_cpros == "NOMATCH"
   if (all(nomatch)) {
-    cli::cli_abort("No Spanish province codes found for {.str {clean_region}}.")
+    abort_no_spanish_codes("province", clean_region)
   }
 
   if (any(nomatch)) {
-    cli::cli_alert_warning(paste0(
-      "No Spanish province codes found for {.str {clean_region[nomatch]}}."
-    ))
+    warn_no_spanish_codes("province", clean_region[nomatch])
   }
 
   nuts_cpros[nomatch] <- NA

--- a/R/utils-convert-names.R
+++ b/R/utils-convert-names.R
@@ -40,10 +40,10 @@ convert_to_nuts <- function(region) {
   sort(unique(nuts_id[!is.na(nuts_id)]))
 }
 
-#' Transform regions to NUTS codes for CCAA (NUTS 2)
+#' Transform regions to NUTS codes for Autonomous Communities (NUTS 2)
 #' @param region A vector of region names or codes (NUTS, ISO2, INE codauto).
-#' @return A vector of NUTS codes for CCAA (level 2) or an error if no valid
-#'   code is found.
+#' @return A vector of NUTS codes for Autonomous Communities (level 2) or an
+#'   error if no valid code is found.
 #'
 #' @noRd
 convert_to_nuts_ccaa <- function(region) {
@@ -79,21 +79,21 @@ convert_to_nuts_ccaa <- function(region) {
   }
 
   if (all(is.na(ccaa_id))) {
-    abort_no_spanish_codes("CCAA", clean_region)
+    abort_no_spanish_codes("Autonomous Communities", clean_region)
   }
 
-  # Map Ceuta and Melilla to their CCAA codes.
+  # Map Ceuta and Melilla to their Autonomous Community codes.
   ccaa_id[grep("ES640", ccaa_id, fixed = TRUE)] <- "ES64"
   ccaa_id[grep("ES630", ccaa_id, fixed = TRUE)] <- "ES63"
 
   novalid <- is.na(ccaa_id) | nchar(ccaa_id) > 4
 
   if (all(novalid)) {
-    abort_no_spanish_codes("CCAA", clean_region)
+    abort_no_spanish_codes("Autonomous Communities", clean_region)
   }
 
   if (any(novalid)) {
-    warn_no_spanish_codes("CCAA", clean_region[novalid])
+    warn_no_spanish_codes("Autonomous Communities", clean_region[novalid])
   }
 
   ccaa_id <- ccaa_id[!novalid]
@@ -138,7 +138,7 @@ convert_to_nuts_prov <- function(region) {
   )
   nuts_cpros <- clean_region
 
-  # Convert text to cpro to check Canary Islands and Balearic Islands.
+  # Convert text to CPRO to check the Canary Islands and Balearic Islands.
   for (i in seq_along(clean_region)) {
     code <- nuts_cpros[i]
     type <- code_type[i]

--- a/R/utils-dict.R
+++ b/R/utils-dict.R
@@ -6,7 +6,7 @@ get_master_codes <- function() {
   df <- mapSpain::esp_codelist
   nt1 <- unique(df$nuts1.code)
 
-  # Second level - NUTS2 - CCAA
+  # Second level: NUTS2 and Autonomous Communities.
   nt2 <- unique(df[, c("nuts2.code", "iso2.ccaa.code", "codauto")])
 
   # Third level - Prov and NUTS
@@ -39,7 +39,7 @@ get_master_codes <- function() {
 
   dict_codes_df$iso2 == "ES-GC"
 
-  # Fake NUTS for Canary Islands
+  # Add synthetic NUTS codes for the Canary Islands.
   dict_codes_df[
     dict_codes_df$iso2 == "ES-GC" & !is.na(dict_codes_df$iso2),
   ]$nuts <- "XXXXX"
@@ -96,7 +96,7 @@ get_master_nuts_nm <- function() {
 
   basecod <- merge(basecod, dict_nuts, all.x = TRUE)
 
-  # Fake NUTS for Canary Islands
+  # Add synthetic NUTS codes for the Canary Islands.
   basecod[basecod$key == "Las Palmas", ]$nuts <- "XXXXX"
   basecod[basecod$key == "Santa Cruz de Tenerife", ]$nuts <- "YYYYY"
   tibble::as_tibble(basecod)

--- a/R/utils-dict.R
+++ b/R/utils-dict.R
@@ -101,3 +101,164 @@ get_master_nuts_nm <- function() {
   basecod[basecod$key == "Santa Cruz de Tenerife", ]$nuts <- "YYYYY"
   tibble::as_tibble(basecod)
 }
+
+nuts_to_cpro <- function(nuts_id) {
+  df <- mapSpain::esp_codelist
+  df <- unique(df[, c("nuts3.code", "cpro")])
+  unique(df[df$nuts3.code %in% nuts_id, ]$cpro)
+}
+
+nuts_to_codauto <- function(nuts_id) {
+  df <- mapSpain::esp_codelist
+  df <- unique(df[, c("nuts2.code", "codauto")])
+  unique(df[df$nuts2.code %in% nuts_id, ]$codauto)
+}
+
+get_ccaa_codes_df <- function() {
+  getnames <- c(
+    "codauto",
+    "iso2.ccaa.code",
+    "nuts1.code",
+    "nuts2.code",
+    "ine.ccaa.name",
+    "iso2.ccaa.name.es",
+    "iso2.ccaa.name.ca",
+    "iso2.ccaa.name.gl",
+    "iso2.ccaa.name.eu",
+    "nuts2.name",
+    "cldr.ccaa.name.en",
+    "cldr.ccaa.name.es",
+    "cldr.ccaa.name.ca",
+    "cldr.ccaa.name.ga",
+    "cldr.ccaa.name.eu",
+    "ccaa.shortname.en",
+    "ccaa.shortname.es",
+    "ccaa.shortname.ca",
+    "ccaa.shortname.ga",
+    "ccaa.shortname.eu"
+  )
+  df_ccaa <- mapSpain::esp_codelist
+  df_ccaa <- df_ccaa[, getnames]
+  df_end <- unique(df_ccaa)
+  df_end <- df_end[order(df_end$codauto), ]
+  df_end
+}
+
+get_prov_codes_df <- function() {
+  getnames <- c(
+    "codauto",
+    "cpro",
+    "iso2.prov.code",
+    "nuts.prov.code",
+    "ine.prov.name",
+    "iso2.prov.name.es",
+    "iso2.prov.name.ca",
+    "iso2.prov.name.ga",
+    "iso2.prov.name.eu",
+    "cldr.prov.name.en",
+    "cldr.prov.name.es",
+    "cldr.prov.name.ca",
+    "cldr.prov.name.ga",
+    "cldr.prov.name.eu",
+    "prov.shortname.en",
+    "prov.shortname.es",
+    "prov.shortname.ca",
+    "prov.shortname.ga",
+    "prov.shortname.eu"
+  )
+
+  df_prov <- mapSpain::esp_codelist
+  df_prov <- df_prov[, getnames]
+  df_end <- unique(df_prov)
+  df_end <- df_end[order(df_end$codauto), ]
+  df_end
+}
+
+get_nuts1_codes_df <- function() {
+  unique(mapSpain::esp_codelist[, c(
+    "nuts2.code",
+    "nuts1.code",
+    "nuts1.name"
+  )])
+}
+
+get_prov_nuts_codes_df <- function() {
+  unique(mapSpain::esp_codelist[, c(
+    "cpro",
+    "nuts2.code",
+    "nuts2.name",
+    "nuts1.code",
+    "nuts1.name"
+  )])
+}
+
+filter_by_cpro_region <- function(data_sf, region) {
+  region <- ensure_null(region)
+  if (is.null(region)) {
+    return(data_sf)
+  }
+
+  tonuts <- convert_to_nuts_prov(region)
+  data_sf[data_sf$cpro %in% nuts_to_cpro(tonuts), ]
+}
+
+filter_by_codauto_region <- function(data_sf, region) {
+  region <- ensure_null(region)
+  if (is.null(region)) {
+    return(data_sf)
+  }
+
+  nuts_id <- convert_to_nuts_ccaa(region)
+  data_sf[data_sf$codauto %in% nuts_to_codauto(nuts_id), ]
+}
+
+filter_by_name_pattern <- function(data_sf, pattern, column) {
+  pattern <- ensure_null(pattern)
+  if (is.null(pattern)) {
+    return(data_sf)
+  }
+
+  pattern <- paste(pattern, collapse = "|")
+  data_sf[grep(pattern, data_sf[[column]], ignore.case = TRUE), ]
+}
+
+add_municipal_metadata <- function(
+  data_sf,
+  id_col,
+  name_col,
+  clean_id = FALSE,
+  validate_cpro = TRUE
+) {
+  lau_code <- data_sf[[id_col]]
+  if (clean_id) {
+    lau_code <- gsub("\\D+", "", lau_code)
+  }
+
+  data_sf$LAU_CODE <- lau_code
+  data_sf$name <- data_sf[[name_col]]
+  data_sf$cpro <- substr(data_sf$LAU_CODE, 1, 2)
+
+  cmun <- substr(data_sf$LAU_CODE, 3, 8)
+  if (validate_cpro) {
+    idprov <- sort(unique(mapSpain::esp_codelist$cpro))
+    cmun <- ifelse(data_sf$cpro %in% idprov, cmun, NA)
+  }
+  data_sf$cmun <- cmun
+
+  merge(
+    data_sf,
+    get_municipal_admin_codes(),
+    by = "cpro",
+    all.x = TRUE,
+    no.dups = TRUE
+  )
+}
+
+get_municipal_admin_codes <- function() {
+  unique(mapSpain::esp_codelist[, c(
+    "codauto",
+    "ine.ccaa.name",
+    "cpro",
+    "ine.prov.name"
+  )])
+}

--- a/R/utils-get-tiles.R
+++ b/R/utils-get-tiles.R
@@ -102,7 +102,7 @@ guess_provider_type <- function(prov_list) {
 }
 
 get_tile_crs <- function(prov_list) {
-  # Get CRS of Tile
+  # Get the tile CRS.
   crs <- unlist(prov_list[
     tolower(names(prov_list)) %in% c("crs", "srs", "tilematrixset")
   ])

--- a/R/utils-get-tiles.R
+++ b/R/utils-get-tiles.R
@@ -96,9 +96,9 @@ guess_provider_type <- function(prov_list) {
   if (is.null(serv)) {
     return("WMTS")
   }
-  toupper(serv)
+
   serv <- unname(unlist(serv))
-  serv
+  toupper(serv)
 }
 
 get_tile_crs <- function(prov_list) {

--- a/R/utils-sf.R
+++ b/R/utils-sf.R
@@ -42,7 +42,7 @@ read_geo_file_sf <- function(file_local, q = NULL, ..., shp_hint = NULL) {
     if (is.null(shp_end)) {
       cli::cli_alert_warning("Cannot read file {.file {file_local}}.")
       cli::cli_abort(paste0(
-        "Please open an issue: ",
+        "Please open an issue at ",
         "{.url https://github.com/rOpenSpain/mapSpain/issues}."
       ))
     }

--- a/R/utils-sf.R
+++ b/R/utils-sf.R
@@ -197,6 +197,11 @@ union_sf_by <- function(data_sf, by) {
   rbind_fill(binded_sf)
 }
 
+sanitize_transform_sf <- function(data_sf, epsg) {
+  data_sf <- sanitize_sf(data_sf)
+  sf::st_transform(data_sf, as.double(epsg))
+}
+
 #' Convert sf object to UTF-8
 #'
 #' Ensures all character columns use UTF-8 encoding.

--- a/R/utils-sf.R
+++ b/R/utils-sf.R
@@ -63,6 +63,140 @@ read_geo_file_sf <- function(file_local, q = NULL, ..., shp_hint = NULL) {
   data_sf
 }
 
+read_siane_files <- function(
+  urls,
+  cache = TRUE,
+  update_cache = FALSE,
+  cache_dir = NULL,
+  verbose = FALSE,
+  codauto = NULL
+) {
+  if (cache) {
+    files <- lapply(
+      urls,
+      download_url,
+      cache_dir = cache_dir,
+      subdir = "siane",
+      update_cache = update_cache,
+      verbose = verbose
+    )
+    missing_file <- vapply(
+      files,
+      function(x) {
+        is.null(ensure_null(x))
+      },
+      FUN.VALUE = logical(1)
+    )
+    if (any(missing_file)) {
+      return(NULL)
+    }
+    files <- unlist(files, use.names = FALSE)
+  } else {
+    files <- urls
+    for (url in urls) {
+      msg <- paste0("{.url ", url, "}.")
+      make_msg("info", verbose, "Reading from", msg)
+    }
+  }
+
+  data_sf <- lapply(seq_along(files), function(i) {
+    sf_file <- read_geo_file_sf(files[i])
+    if (!is.null(codauto)) {
+      sf_file$codauto <- codauto[i]
+    }
+    sf_file
+  })
+
+  rbind_fill(data_sf)
+}
+
+download_and_read_geo_file <- function(
+  url,
+  subdir,
+  name = basename(url),
+  update_cache = FALSE,
+  cache_dir = NULL,
+  verbose = FALSE,
+  ...
+) {
+  file_local <- download_url(
+    url,
+    name = name,
+    cache_dir = cache_dir,
+    subdir = subdir,
+    update_cache = update_cache,
+    verbose = verbose
+  )
+  if (is.null(file_local)) {
+    return(NULL)
+  }
+
+  read_geo_file_sf(file_local, ...)
+}
+
+download_unzip_read_geo_file <- function(
+  url,
+  subdir,
+  member,
+  update_cache = FALSE,
+  cache_dir = NULL,
+  verbose = FALSE
+) {
+  file_local <- download_url(
+    url,
+    cache_dir = cache_dir,
+    subdir = subdir,
+    update_cache = update_cache,
+    verbose = verbose
+  )
+  if (is.null(file_local)) {
+    return(NULL)
+  }
+
+  path <- gsub(basename(file_local), "", file_local)
+  unzip(file_local, exdir = path, junkpaths = TRUE)
+  read_geo_file_sf(file.path(path, member))
+}
+
+download_rds <- function(
+  url,
+  subdir,
+  update_cache = FALSE,
+  cache_dir = NULL,
+  verbose = FALSE
+) {
+  file_local <- download_url(
+    url,
+    cache_dir = cache_dir,
+    subdir = subdir,
+    update_cache = update_cache,
+    verbose = verbose
+  )
+  if (is.null(file_local)) {
+    return(NULL)
+  }
+
+  readRDS(file_local)
+}
+
+union_sf_by <- function(data_sf, by) {
+  values <- unique(data_sf[[by]])
+  binded_sf <- lapply(values, function(x) {
+    the_geom <- data_sf[data_sf[[by]] == x, ]
+    if (nrow(the_geom) == 1) {
+      return(the_geom)
+    }
+
+    g <- sf::st_union(sf::st_geometry(the_geom))
+    out <- sf::st_sf(geometry = g)
+    out[[by]] <- x
+    out <- out[, c(by, "geometry")]
+    out
+  })
+
+  rbind_fill(binded_sf)
+}
+
 #' Convert sf object to UTF-8
 #'
 #' Ensures all character columns use UTF-8 encoding.

--- a/R/utils-url.R
+++ b/R/utils-url.R
@@ -73,8 +73,6 @@ download_url <- function(
     return(alert_return_null())
   }
 
-  # Response
-
   # Use HEAD to check whether the download is large enough to warn about.
   get_header <- httr2::req_method(req, "HEAD")
   getsize <- httr2::req_perform(get_header)
@@ -84,7 +82,7 @@ download_url <- function(
   thr <- 50 * (1024^2)
   if (size_dwn > thr) {
     sz_dwn <- paste0(format(size_dwn, units = "auto"), ".")
-    make_msg("warning", TRUE, "The file to be downloaded has size", sz_dwn)
+    make_msg("warning", TRUE, "The download size is", sz_dwn)
     req <- httr2::req_progress(req)
   }
 
@@ -113,7 +111,7 @@ download_url <- function(
     alert_open_issue()
     return(alert_return_null())
   }
-  msg <- paste0("Download successful on {.file ", file_local, "}.")
+  msg <- paste0("Download saved to {.file ", file_local, "}.")
   make_msg("success", verbose, msg)
 
   file_local

--- a/R/utils-url.R
+++ b/R/utils-url.R
@@ -70,8 +70,7 @@ download_url <- function(
 
   if (!is_online_fun()) {
     cli::cli_alert_danger("Offline.")
-    cli::cli_alert("Returning {.val NULL}.")
-    return(NULL)
+    return(alert_return_null())
   }
 
   # Response
@@ -111,12 +110,8 @@ download_url <- function(
       "{.strong Error {get_status_code}} ({get_status_desc}):",
       " {.url {url}}."
     ))
-    cli::cli_alert_warning(c(
-      "If you think this is a bug, please consider opening an issue on ",
-      "{.url https://github.com/rOpenSpain/mapSpain/issues}"
-    ))
-    cli::cli_alert("Returning {.val NULL}.")
-    return(NULL)
+    alert_open_issue()
+    return(alert_return_null())
   }
   msg <- paste0("Download successful on {.file ", file_local, "}.")
   make_msg("success", verbose, msg)

--- a/R/utils.R
+++ b/R/utils.R
@@ -18,21 +18,15 @@ make_msg <- function(type = "generic", verbose, ...) {
   dots <- list(...)
   msg <- paste(dots, collapse = " ")
 
-  if (type == "generic") {
-    cli::cli_alert(msg)
-  }
-  if (type == "success") {
-    cli::cli_alert_success(msg)
-  }
-  if (type == "warning") {
-    cli::cli_alert_warning(msg)
-  }
-  if (type == "danger") {
-    cli::cli_alert_danger(msg)
-  }
-  if (type == "info") {
-    cli::cli_alert_info(msg)
-  }
+  alert <- switch(type,
+    generic = cli::cli_alert,
+    success = cli::cli_alert_success,
+    warning = cli::cli_alert_warning,
+    danger = cli::cli_alert_danger,
+    info = cli::cli_alert_info,
+    cli::cli_alert
+  )
+  alert(msg)
   invisible()
 }
 
@@ -193,4 +187,51 @@ validate_non_empty_arg <- function(arg, call = parent.frame(1)) {
   }
 
   arg
+}
+
+validate_epsg <- function(epsg, choices = c("4326", "4258", "3035", "3857")) {
+  match_arg_pretty(epsg, choices)
+}
+
+is_moving_can <- function(moveCAN) {
+  isTRUE(moveCAN) | length(moveCAN) > 1
+}
+
+merge_db_value_desc <- function(data_sf, field, names) {
+  values <- db_valores[db_valores$campo == field, 2:3]
+  names(values) <- names
+
+  merge(data_sf, values, all.x = TRUE)
+}
+
+return_empty_sf <- function(data_sf, warning, .envir = parent.frame()) {
+  cli::cli_alert_warning(warning, .envir = .envir)
+  cli::cli_alert_info("Returning empty {.cls sf} object.")
+  data_sf
+}
+
+return_empty_name_sf <- function(data_sf, name) {
+  return_empty_sf(data_sf, "No results for {.arg name} {.str {name}}.")
+}
+
+return_empty_combination_sf <- function(data_sf, arg) {
+  return_empty_sf(
+    data_sf,
+    paste0(
+      "The combination of {.arg region}, {.arg {arg}} or both does not ",
+      "return any results."
+    )
+  )
+}
+
+alert_return_null <- function() {
+  cli::cli_alert("Returning {.val NULL}.")
+  NULL
+}
+
+alert_open_issue <- function() {
+  cli::cli_alert_warning(c(
+    "If you think this is a bug, please consider opening an issue on ",
+    "{.url https://github.com/rOpenSpain/mapSpain/issues}"
+  ))
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -224,6 +224,32 @@ return_empty_combination_sf <- function(data_sf, arg) {
   )
 }
 
+warn_no_spanish_codes <- function(code_type, values) {
+  cli::cli_alert_warning(
+    "No Spanish {code_type} codes found for {.str {values}}."
+  )
+}
+
+abort_no_spanish_codes <- function(code_type, values, call = parent.frame()) {
+  cli::cli_abort(
+    "No Spanish {code_type} codes found for {.str {values}}.",
+    call = call
+  )
+}
+
+warn_no_match <- function(values, destination = NULL) {
+  if (is.null(destination)) {
+    cli::cli_alert_warning("No match found for {.str {values}}.")
+    return(invisible())
+  }
+
+  cli::cli_alert_warning(paste0(
+    "No match on {.arg destination = {.str {destination}}} found ",
+    "for {.str {values}}."
+  ))
+  invisible()
+}
+
 alert_return_null <- function() {
   cli::cli_alert("Returning {.val NULL}.")
   NULL

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ A BibTeX entry for LaTeX users is:
     @Manual{R-mapspain,
       title = {{mapSpain}: Administrative Boundaries of Spain},
       year = {2026},
-      version = {1.1.0},
+      version = {1.1.0.9000},
       author = {Diego Hernangómez},
       doi = {10.5281/zenodo.5366622},
       url = {https://ropenspain.github.io/mapSpain/},

--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@
 
 <!-- badges: end -->
 
-[**mapSpain**](https://ropenspain.github.io/mapSpain/) is a package that
-provides **sf** objects of Spain’s administrative boundaries, including
-Autonomous Communities, provinces and municipalities.
+[**mapSpain**](https://ropenspain.github.io/mapSpain/) provides **sf**
+objects for Spain’s administrative boundaries, including Autonomous
+Communities, provinces and municipalities.
 
-**mapSpain** also provides a plugin for the [**leaflet**
-package](https://rstudio.github.io/leaflet/). It loads several basemaps
-from Spain’s public institutions and enables downloading and processing
-static tiles.
+**mapSpain** also provides a plugin for the
+[**leaflet**](https://rstudio.github.io/leaflet/) package. It loads
+several basemaps from Spain’s public institutions and supports
+downloading and processing static tiles.
 
 The full package website, with examples and vignettes, is available at
 <https://ropenspain.github.io/mapSpain/>.
@@ -83,14 +83,14 @@ library(dplyr)
 census <- mapSpain::pobmun25 |>
   select(-name)
 
-# Extract CCAA from the base dataset.
+# Extract Autonomous Community codes from the base dataset.
 codelist <- mapSpain::esp_codelist |>
   select(cpro, codauto) |>
   distinct()
 
 census_ccaa <- census |>
   left_join(codelist) |>
-  # Summarize by CCAA.
+  # Summarize by Autonomous Community.
   group_by(codauto) |>
   summarise(pob25 = sum(pob25), men = sum(men), women = sum(women)) |>
   mutate(
@@ -131,7 +131,7 @@ ggplot(ccaa_sf) +
 <img src="man/figures/README-static-1.png" style="width:100.0%"
 alt="Percentage of women by Autonomous Community in Spain (2025)" />
 
-You can combine `sf` objects with static tiles.
+You can combine `sf` objects with static map tiles.
 
 ``` r
 # Get census data.
@@ -139,7 +139,7 @@ census <- mapSpain::pobmun25 |>
   mutate(porc_women = women / pob25) |>
   select(cpro, cmun, porc_women)
 
-# Get geometries.
+# Get municipality and province geometries.
 shape <- esp_get_munic_siane(region = "Segovia", epsg = 3857)
 provs <- esp_get_prov_siane(epsg = 3857)
 
@@ -189,9 +189,9 @@ alt="Percentage of women in Segovia by municipality (2025)" />
 
 ## mapSpain and giscoR
 
-If you need to plot Spain alongside other countries, consider using the
+If you need to plot Spain alongside other countries, use the
 [**giscoR**](https://ropengov.github.io/giscoR/) package, which is
-installed as a dependency with **mapSpain**. Here is a basic example:
+installed as a dependency of **mapSpain**. Here is a basic example:
 
 ``` r
 library(giscoR)
@@ -230,15 +230,15 @@ alt="Locator map of Spain" />
 ## A note on caching
 
 Some datasets and tiles may be larger than 50 MB. You can use
-**mapSpain** to create your own local repository in a given local
-directory by setting the following option:
+**mapSpain** to create a local cache directory by setting the following
+option:
 
 ``` r
 esp_set_cache_dir("./path/to/location")
 ```
 
-When this option is set, **mapSpain** looks for the cached file and
-loads it, which speeds up subsequent calls.
+When this option is set, **mapSpain** looks for cached files before
+downloading them again, which speeds up subsequent calls.
 
 ## Citation
 
@@ -259,7 +259,7 @@ A BibTeX entry for LaTeX users is:
       author = {Diego Hernangómez},
       doi = {10.5281/zenodo.5366622},
       url = {https://ropenspain.github.io/mapSpain/},
-      abstract = {Administrative boundaries of Spain at several levels (Autonomous Communities, provinces and municipalities), based on GISCO from Eurostat <https://ec.europa.eu/eurostat/web/gisco> and CartoBase ANE from Instituto Geográfico Nacional <https://www.ign.es/>. It also provides a plugin for leaflet and tools to download and process static map tiles.},
+      abstract = {Administrative boundaries of Spain at several levels (Autonomous Communities, provinces and municipalities), based on GISCO from Eurostat <https://ec.europa.eu/eurostat/web/gisco> and CartoBase ANE from Instituto Geográfico Nacional <https://www.ign.es/>. It also provides a plugin for the leaflet package and tools to download and process static map tiles.},
     }
 
 ## Contribute
@@ -269,14 +269,14 @@ code](https://github.com/ropenspain/mapSpain/).
 
 ## Copyright notice
 
-This package uses data from CartoBase SIANE, provided by Instituto
+This package uses data from CartoBase SIANE, provided by the Instituto
 Geográfico Nacional.
 
 > Atlas Nacional de España (ANE) [CC BY
 > 4.0](https://creativecommons.org/licenses/by/4.0/deed.en)
 > [ign.es](https://www.ign.es/)
 
-See <https://github.com/rOpenSpain/mapSpain/tree/sianedata>
+See <https://github.com/rOpenSpain/mapSpain/tree/sianedata>.
 
 This package also uses data from GISCO. GISCO
 [(FAQ)](https://ec.europa.eu/eurostat/web/gisco) is a geospatial open

--- a/README.qmd
+++ b/README.qmd
@@ -31,13 +31,14 @@ knitr:
 
 <!-- badges: end -->
 
-[**mapSpain**](https://ropenspain.github.io/mapSpain/) is a package that
-provides **sf** objects of Spain's administrative boundaries, including
-Autonomous Communities, provinces and municipalities.
+[**mapSpain**](https://ropenspain.github.io/mapSpain/) provides **sf** objects
+for Spain's administrative boundaries, including Autonomous Communities,
+provinces and municipalities.
 
-**mapSpain** also provides a plugin for the [**leaflet**
-package](https://rstudio.github.io/leaflet/). It loads several basemaps from
-Spain's public institutions and enables downloading and processing static tiles.
+**mapSpain** also provides a plugin for the
+[**leaflet**](https://rstudio.github.io/leaflet/) package. It loads several
+basemaps from Spain's public institutions and supports downloading and
+processing static tiles.
 
 The full package website, with examples and vignettes, is available at
 <https://ropenspain.github.io/mapSpain/>.
@@ -96,14 +97,14 @@ library(dplyr)
 census <- mapSpain::pobmun25 |>
   select(-name)
 
-# Extract CCAA from the base dataset.
+# Extract Autonomous Community codes from the base dataset.
 codelist <- mapSpain::esp_codelist |>
   select(cpro, codauto) |>
   distinct()
 
 census_ccaa <- census |>
   left_join(codelist) |>
-  # Summarize by CCAA.
+  # Summarize by Autonomous Community.
   group_by(codauto) |>
   summarise(pob25 = sum(pob25), men = sum(men), women = sum(women)) |>
   mutate(
@@ -141,7 +142,7 @@ ggplot(ccaa_sf) +
   labs(caption = "Source: CartoBase ANE 2006-2024 CC-BY 4.0 ign.es, INE")
 ```
 
-You can combine `sf` objects with static tiles.
+You can combine `sf` objects with static map tiles.
 
 ```{r}
 #| label: tile
@@ -151,7 +152,7 @@ census <- mapSpain::pobmun25 |>
   mutate(porc_women = women / pob25) |>
   select(cpro, cmun, porc_women)
 
-# Get geometries.
+# Get municipality and province geometries.
 shape <- esp_get_munic_siane(region = "Segovia", epsg = 3857)
 provs <- esp_get_prov_siane(epsg = 3857)
 
@@ -198,9 +199,9 @@ ggplot(remove_missing(shape_pop, na.rm = TRUE)) +
 
 ## mapSpain and giscoR
 
-If you need to plot Spain alongside other countries, consider using the
+If you need to plot Spain alongside other countries, use the
 [**giscoR**](https://ropengov.github.io/giscoR/) package, which is installed as
-a dependency with **mapSpain**. Here is a basic example:
+a dependency of **mapSpain**. Here is a basic example:
 
 ```{r}
 #| label: giscoR
@@ -238,16 +239,15 @@ ggplot(all_countries) +
 ## A note on caching
 
 Some datasets and tiles may be larger than 50 MB. You can use **mapSpain** to
-create your own local repository in a given local directory by setting the
-following option:
+create a local cache directory by setting the following option:
 
 ```{r}
 #| eval: false
 esp_set_cache_dir("./path/to/location")
 ```
 
-When this option is set, **mapSpain** looks for the cached file and loads it,
-which speeds up subsequent calls.
+When this option is set, **mapSpain** looks for cached files before downloading
+them again, which speeds up subsequent calls.
 
 ## Citation
 
@@ -272,14 +272,14 @@ code](https://github.com/ropenspain/mapSpain/).
 
 ## Copyright notice
 
-This package uses data from CartoBase SIANE, provided by Instituto Geográfico
-Nacional.
+This package uses data from CartoBase SIANE, provided by the Instituto
+Geográfico Nacional.
 
 > Atlas Nacional de España (ANE) [CC BY
 > 4.0](https://creativecommons.org/licenses/by/4.0/deed.en)
 > [ign.es](https://www.ign.es/)
 
-See <https://github.com/rOpenSpain/mapSpain/tree/sianedata>
+See <https://github.com/rOpenSpain/mapSpain/tree/sianedata>.
 
 This package also uses data from GISCO. GISCO
 [(FAQ)](https://ec.europa.eu/eurostat/web/gisco) is a geospatial open data

--- a/codemeta.json
+++ b/codemeta.json
@@ -314,7 +314,7 @@
   "applicationCategory": "cartography",
   "isPartOf": "https://ropenspain.es/",
   "keywords": ["ropenspain", "tiles", "r", "maps", "spatial", "rstats", "r-package", "municipalities", "spain", "gisco", "provinces", "ign", "administrative-boundaries", "ccaa", "static-tiles", "cran", "ggplot2", "gis"],
-  "fileSize": "1795.603KB",
+  "fileSize": "1797.339KB",
   "citation": [
     {
       "@type": "SoftwareSourceCode",

--- a/codemeta.json
+++ b/codemeta.json
@@ -8,7 +8,7 @@
   "codeRepository": "https://github.com/rOpenSpain/mapSpain",
   "issueTracker": "https://github.com/rOpenSpain/mapSpain/issues",
   "license": "https://spdx.org/licenses/GPL-3.0",
-  "version": "1.1.0",
+  "version": "1.1.0.9000",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",
@@ -113,6 +113,19 @@
         "url": "https://cran.r-project.org"
       },
       "sameAs": "https://CRAN.R-project.org/package=quarto"
+    },
+    {
+      "@type": "SoftwareApplication",
+      "identifier": "testthat",
+      "name": "testthat",
+      "version": ">= 3.0.0",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Comprehensive R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      },
+      "sameAs": "https://CRAN.R-project.org/package=testthat"
     },
     {
       "@type": "SoftwareApplication",
@@ -276,19 +289,6 @@
     },
     "12": {
       "@type": "SoftwareApplication",
-      "identifier": "testthat",
-      "name": "testthat",
-      "version": ">= 3.0.0",
-      "provider": {
-        "@id": "https://cran.r-project.org",
-        "@type": "Organization",
-        "name": "Comprehensive R Archive Network (CRAN)",
-        "url": "https://cran.r-project.org"
-      },
-      "sameAs": "https://CRAN.R-project.org/package=testthat"
-    },
-    "13": {
-      "@type": "SoftwareApplication",
       "identifier": "tibble",
       "name": "tibble",
       "provider": {
@@ -299,12 +299,12 @@
       },
       "sameAs": "https://CRAN.R-project.org/package=tibble"
     },
-    "14": {
+    "13": {
       "@type": "SoftwareApplication",
       "identifier": "tools",
       "name": "tools"
     },
-    "15": {
+    "14": {
       "@type": "SoftwareApplication",
       "identifier": "utils",
       "name": "utils"
@@ -314,7 +314,7 @@
   "applicationCategory": "cartography",
   "isPartOf": "https://ropenspain.es/",
   "keywords": ["ropenspain", "tiles", "r", "maps", "spatial", "rstats", "r-package", "municipalities", "spain", "gisco", "provinces", "ign", "administrative-boundaries", "ccaa", "static-tiles", "cran", "ggplot2", "gis"],
-  "fileSize": "1805.814KB",
+  "fileSize": "1795.603KB",
   "citation": [
     {
       "@type": "SoftwareSourceCode",

--- a/codemeta.json
+++ b/codemeta.json
@@ -2,7 +2,7 @@
   "@context": "https://doi.org/10.5063/schema/codemeta-2.0",
   "@type": "SoftwareSourceCode",
   "identifier": "mapSpain",
-  "description": "Administrative boundaries of Spain at several levels (Autonomous Communities, provinces and municipalities), based on 'GISCO' from 'Eurostat' <https://ec.europa.eu/eurostat/web/gisco> and 'CartoBase ANE' from 'Instituto Geográfico Nacional' <https://www.ign.es/>. It also provides a plugin for 'leaflet' and tools to download and process static map tiles.",
+  "description": "Administrative boundaries of Spain at several levels (Autonomous Communities, provinces and municipalities), based on 'GISCO' from 'Eurostat' <https://ec.europa.eu/eurostat/web/gisco> and 'CartoBase ANE' from 'Instituto Geográfico Nacional' <https://www.ign.es/>. It also provides a plugin for the 'leaflet' package and tools to download and process static map tiles.",
   "name": "mapSpain: Administrative Boundaries of Spain",
   "relatedLink": ["https://ropenspain.github.io/mapSpain/", "https://CRAN.R-project.org/package=mapSpain"],
   "codeRepository": "https://github.com/rOpenSpain/mapSpain",
@@ -314,7 +314,7 @@
   "applicationCategory": "cartography",
   "isPartOf": "https://ropenspain.es/",
   "keywords": ["ropenspain", "tiles", "r", "maps", "spatial", "rstats", "r-package", "municipalities", "spain", "gisco", "provinces", "ign", "administrative-boundaries", "ccaa", "static-tiles", "cran", "ggplot2", "gis"],
-  "fileSize": "1797.339KB",
+  "fileSize": "1800.107KB",
   "citation": [
     {
       "@type": "SoftwareSourceCode",

--- a/inst/schemaorg.json
+++ b/inst/schemaorg.json
@@ -45,7 +45,7 @@
         "url": "https://cran.r-project.org"
       },
       "runtimePlatform": "R version 4.6.0 (2026-04-24 ucrt)",
-      "version": "1.1.0"
+      "version": "1.1.0.9000"
     },
     {
       "id": "https://doi.org/10.5281/zenodo.5366622",

--- a/inst/schemaorg.json
+++ b/inst/schemaorg.json
@@ -30,7 +30,7 @@
           "name": "Instituto Geográfico Nacional"
         }
       ],
-      "description": "Administrative boundaries of Spain at several levels (Autonomous Communities, provinces and municipalities), based on 'GISCO' from 'Eurostat' <https://ec.europa.eu/eurostat/web/gisco> and 'CartoBase ANE' from 'Instituto Geográfico Nacional' <https://www.ign.es/>. It also provides a plugin for 'leaflet' and tools to download and process static map tiles.",
+      "description": "Administrative boundaries of Spain at several levels (Autonomous Communities, provinces and municipalities), based on 'GISCO' from 'Eurostat' <https://ec.europa.eu/eurostat/web/gisco> and 'CartoBase ANE' from 'Instituto Geográfico Nacional' <https://www.ign.es/>. It also provides a plugin for the 'leaflet' package and tools to download and process static map tiles.",
       "license": "https://spdx.org/licenses/GPL-3.0",
       "name": "mapSpain: Administrative Boundaries of Spain",
       "programmingLanguage": {

--- a/man/addProviderEspTiles.Rd
+++ b/man/addProviderEspTiles.Rd
@@ -64,7 +64,7 @@ leafmap
 \code{\link[leaflet:leaflet]{leaflet::leaflet()}}, \code{\link[leaflet:addTiles]{leaflet::addTiles()}}, \code{\link[leaflet:addWMSTiles]{leaflet::addWMSTiles()}},
 \link{esp_tiles_providers}.
 
-Other functions for creating maps with images:
+Functions for image-based maps and tile providers:
 \code{\link[=esp_get_tiles]{esp_get_tiles()}},
 \code{\link[=esp_make_provider]{esp_make_provider()}}
 }

--- a/man/esp_clear_cache.Rd
+++ b/man/esp_clear_cache.Rd
@@ -53,7 +53,7 @@ identical(my_cache, esp_detect_cache_dir())
 \seealso{
 \code{\link[tools:R_user_dir]{tools::R_user_dir()}}
 
-Other cache utilities:
+Cache management utilities:
 \code{\link[=esp_set_cache_dir]{esp_set_cache_dir()}}
 }
 \concept{cache utilities}

--- a/man/esp_codelist.Rd
+++ b/man/esp_codelist.Rd
@@ -10,55 +10,55 @@ A \link[tibble:tbl_df]{tibble} with 59 rows and
 columns:
 
 \describe{
-\item{nuts1.code}{NUTS 1 code}
-\item{nuts1.name}{NUTS 1 name}
-\item{nuts1.name.alt}{NUTS 1 alternative name}
-\item{nuts1.shortname.es}{NUTS 1 short (common) name (Spanish)}
-\item{codauto}{INE code of the Autonomous Community}
-\item{iso2.ccaa.code}{ISO2 code of the Autonomous Community}
-\item{nuts2.code}{NUTS 2 code}
-\item{ine.ccaa.name}{INE name of the Autonomous Community}
-\item{iso2.ccaa.name.es}{ISO2 name of the Autonomous Community (Spanish)}
-\item{iso2.ccaa.name.ca}{ISO2 name of the Autonomous Community (Catalan)}
-\item{iso2.ccaa.name.gl}{ISO2 name of the Autonomous Community (Galician)}
-\item{iso2.ccaa.name.eu}{ISO2 name of the Autonomous Community (Basque)}
-\item{nuts2.name}{NUTS 2 name}
-\item{cldr.ccaa.name.en}{CLDR name of the Autonomous Community (English)}
-\item{cldr.ccaa.name.es}{CLDR name of the Autonomous Community (Spanish)}
-\item{cldr.ccaa.name.ca}{CLDR name of the Autonomous Community (Catalan)}
-\item{cldr.ccaa.name.ga}{CLDR name of the Autonomous Community (Galician)}
-\item{cldr.ccaa.name.eu}{CLDR name of the Autonomous Community (Basque)}
+\item{nuts1.code}{NUTS 1 code.}
+\item{nuts1.name}{NUTS 1 name.}
+\item{nuts1.name.alt}{NUTS 1 alternative name.}
+\item{nuts1.shortname.es}{NUTS 1 short (common) name (Spanish).}
+\item{codauto}{INE code of the Autonomous Community.}
+\item{iso2.ccaa.code}{ISO2 code of the Autonomous Community.}
+\item{nuts2.code}{NUTS 2 code.}
+\item{ine.ccaa.name}{INE name of the Autonomous Community.}
+\item{iso2.ccaa.name.es}{ISO2 name of the Autonomous Community (Spanish).}
+\item{iso2.ccaa.name.ca}{ISO2 name of the Autonomous Community (Catalan).}
+\item{iso2.ccaa.name.gl}{ISO2 name of the Autonomous Community (Galician).}
+\item{iso2.ccaa.name.eu}{ISO2 name of the Autonomous Community (Basque).}
+\item{nuts2.name}{NUTS 2 name.}
+\item{cldr.ccaa.name.en}{CLDR name of the Autonomous Community (English).}
+\item{cldr.ccaa.name.es}{CLDR name of the Autonomous Community (Spanish).}
+\item{cldr.ccaa.name.ca}{CLDR name of the Autonomous Community (Catalan).}
+\item{cldr.ccaa.name.ga}{CLDR name of the Autonomous Community (Galician).}
+\item{cldr.ccaa.name.eu}{CLDR name of the Autonomous Community (Basque).}
 \item{ccaa.shortname.en}{Short (common) name of the Autonomous Community
-(English)}
+(English).}
 \item{ccaa.shortname.es}{Short (common) name of the Autonomous Community
-(Spanish)}
+(Spanish).}
 \item{ccaa.shortname.ca}{Short (common) name of the Autonomous Community
-(Catalan)}
+(Catalan).}
 \item{ccaa.shortname.ga}{Short (common) name of the Autonomous Community
-(Galician)}
+(Galician).}
 \item{ccaa.shortname.eu}{Short (common) name of the Autonomous Community
-(Basque)}
-\item{cpro}{INE code of the province}
-\item{iso2.prov.code}{ISO2 code of the province}
-\item{nuts.prov.code}{NUTS code of the province}
-\item{ine.prov.name}{INE name of the province}
-\item{iso2.prov.name.es}{ISO2 name of the province (Spanish)}
-\item{iso2.prov.name.ca}{ISO2 name of the province (Catalan)}
-\item{iso2.prov.name.ga}{ISO2 name of the province (Galician)}
-\item{iso2.prov.name.eu}{ISO2 name of the province (Basque)}
-\item{cldr.prov.name.en}{CLDR name of the province (English)}
-\item{cldr.prov.name.es}{CLDR name of the province (Spanish)}
-\item{cldr.prov.name.ca}{CLDR name of the province (Catalan)}
-\item{cldr.prov.name.ga}{CLDR name of the province (Galician)}
-\item{cldr.prov.name.eu}{CLDR name of the province (Basque)}
-\item{prov.shortname.en}{Short (common) name of the province (English)}
-\item{prov.shortname.es}{Short (common) name of the province (Spanish)}
-\item{prov.shortname.ca}{Short (common) name of the province (Catalan)}
-\item{prov.shortname.ga}{Short (common) name of the province (Galician)}
-\item{prov.shortname.eu}{Short (common) name of the province (Basque)}
-\item{nuts3.code}{NUTS 3 code}
-\item{nuts3.name}{NUTS 3 name}
-\item{nuts3.shortname.es}{NUTS 3 short (common) name}
+(Basque).}
+\item{cpro}{INE code of the province.}
+\item{iso2.prov.code}{ISO2 code of the province.}
+\item{nuts.prov.code}{NUTS code of the province.}
+\item{ine.prov.name}{INE name of the province.}
+\item{iso2.prov.name.es}{ISO2 name of the province (Spanish).}
+\item{iso2.prov.name.ca}{ISO2 name of the province (Catalan).}
+\item{iso2.prov.name.ga}{ISO2 name of the province (Galician).}
+\item{iso2.prov.name.eu}{ISO2 name of the province (Basque).}
+\item{cldr.prov.name.en}{CLDR name of the province (English).}
+\item{cldr.prov.name.es}{CLDR name of the province (Spanish).}
+\item{cldr.prov.name.ca}{CLDR name of the province (Catalan).}
+\item{cldr.prov.name.ga}{CLDR name of the province (Galician).}
+\item{cldr.prov.name.eu}{CLDR name of the province (Basque).}
+\item{prov.shortname.en}{Short (common) name of the province (English).}
+\item{prov.shortname.es}{Short (common) name of the province (Spanish).}
+\item{prov.shortname.ca}{Short (common) name of the province (Catalan).}
+\item{prov.shortname.ga}{Short (common) name of the province (Galician).}
+\item{prov.shortname.eu}{Short (common) name of the province (Basque).}
+\item{nuts3.code}{NUTS 3 code.}
+\item{nuts3.name}{NUTS 3 name.}
+\item{nuts3.shortname.es}{NUTS 3 short (common) name.}
 }
 }
 \source{
@@ -74,12 +74,12 @@ columns:
 A \link[tibble:tbl_df]{tibble} object used internally for translating codes and
 names of the different subdivisions of Spain. This tibble provides a
 hierarchical representation of Spain's subdivisions, including NUTS1 level,
-Autonomous Communities (equivalent to NUTS2), provinces and NUTS3 level.
+Autonomous Communities (equivalent to NUTS2), provinces and NUTS3 levels.
 See the note below for coverage details.
 }
 \note{
 Although NUTS2 aligns with the first subdivision level of Spain
-(Autonomous Communities, CCAA), NUTS3 does not correspond to the second
+(Autonomous Communities), NUTS3 does not correspond to the second
 subdivision level of Spain (provinces). NUTS3
 provides dedicated codes for major islands, whereas provinces do not.
 
@@ -93,7 +93,7 @@ data("esp_codelist")
 esp_codelist
 }
 \seealso{
-Other datasets:
+Included package datasets:
 \code{\link{esp_nuts_2024}},
 \code{\link{esp_tiles_providers}},
 \code{\link{pobmun25}}

--- a/man/esp_dict.Rd
+++ b/man/esp_dict.Rd
@@ -32,12 +32,12 @@ translation per input is returned as a character vector.}
 }
 \value{
 \code{esp_dict_region_code()} returns a character vector with converted
-subdivision identifiers or names. If a value cannot be matched the
+subdivision identifiers or names. If a value cannot be matched, the
 corresponding element will be \code{NA} and a warning is emitted via
 \code{\link[cli:cli_alert_warning]{cli::cli_alert_warning()}}.
 
 \code{esp_dict_translate()} translates a vector of names from one language to
-another:
+another.
 \itemize{
 \item If \code{all = FALSE}, a character vector with the translated name for each
 element of \code{sourcevar}.
@@ -47,7 +47,7 @@ all available translations for the corresponding input value.
 }
 \description{
 Convert Spanish subdivision names or identifiers between different coding
-schemes, such as NUTS, ISO2 and province codes, or obtain human-readable
+schemes such as NUTS, ISO2 and province codes, or obtain human-readable
 names.
 }
 \details{

--- a/man/esp_get_can_box.Rd
+++ b/man/esp_get_can_box.Rd
@@ -107,7 +107,7 @@ ggplot(countries) +
 }
 }
 \seealso{
-Other helpers for the Canary Islands:
+Helpers for Canary Islands insets and displacement:
 \code{\link[=esp_move_can]{esp_move_can()}}
 }
 \concept{can_helpers}

--- a/man/esp_get_capimun.Rd
+++ b/man/esp_get_capimun.Rd
@@ -97,8 +97,8 @@ When using \code{region} you can use and mix names and NUTS codes (levels 1, 2 o
 3), ISO codes (corresponding to level 2 or 3) or \code{"cpro"}
 (see \link{esp_codelist}).
 
-When calling a higher level (province, CCAA or NUTS1), all the municipalities
-of that level will be added.
+When calling a higher level (province, Autonomous Community or NUTS1), all
+the municipalities of that level will be added.
 }
 \note{
 Although \CRANpkg{mapSpain} supplies cartographically suitable datasets,
@@ -146,7 +146,7 @@ ggplot(points) +
 \dontshow{\}) # examplesIf}
 }
 \seealso{
-Other datasets representing political borders:
+Political and administrative boundary datasets:
 \code{\link[=esp_get_ccaa]{esp_get_ccaa()}},
 \code{\link[=esp_get_ccaa_siane]{esp_get_ccaa_siane()}},
 \code{\link[=esp_get_comarca]{esp_get_comarca()}},
@@ -162,7 +162,7 @@ Other datasets representing political borders:
 \code{\link[=esp_get_spain_siane]{esp_get_spain_siane()}},
 \code{\link[=esp_siane_bulk_download]{esp_siane_bulk_download()}}
 
-Political borders from CartoBase ANE:
+Datasets sourced from CartoBase ANE:
 \code{\link[=esp_get_ccaa_siane]{esp_get_ccaa_siane()}},
 \code{\link[=esp_get_countries_siane]{esp_get_countries_siane()}},
 \code{\link[=esp_get_munic_siane]{esp_get_munic_siane()}},
@@ -170,7 +170,7 @@ Political borders from CartoBase ANE:
 \code{\link[=esp_get_spain_siane]{esp_get_spain_siane()}},
 \code{\link[=esp_siane_bulk_download]{esp_siane_bulk_download()}}
 
-Datasets representing municipalities:
+Municipality-level datasets:
 \code{\link[=esp_get_munic]{esp_get_munic()}},
 \code{\link[=esp_get_munic_siane]{esp_get_munic_siane()}}
 }

--- a/man/esp_get_ccaa.Rd
+++ b/man/esp_get_ccaa.Rd
@@ -78,12 +78,10 @@ Ceuta and Melilla are considered as Autonomous Communities in this function.
 When calling a NUTS1 level, all the Autonomous Communities of that level
 will be added.
 }
-\section{Note}{
-
-Please check the download and usage provisions on \code{\link[giscoR:gisco_attributions]{gisco_attributions()}}.
-
+\note{
+Please check the download and usage provisions on
+\code{\link[giscoR:gisco_attributions]{giscoR::gisco_attributions()}}.
 }
-
 \examples{
 ccaa <- esp_get_ccaa()
 
@@ -92,7 +90,7 @@ library(ggplot2)
 ggplot(ccaa) +
   geom_sf()
 
-# Random CCAA
+# Random Autonomous Communities
 random_ccaa <- esp_get_ccaa(ccaa = c(
   "Euskadi",
   "Catalunya",
@@ -107,7 +105,7 @@ ggplot(random_ccaa) +
   geom_sf_label(aes(label = codauto), alpha = 0.3) +
   coord_sf(crs = 3857)
 
-# All CCAA of a Zone plus an addition
+# All Autonomous Communities of a NUTS1 region plus an addition
 
 mixed <- esp_get_ccaa(ccaa = c("La Rioja", "Noroeste"))
 
@@ -137,7 +135,7 @@ ggplot(europe) +
 }
 }
 \seealso{
-Other datasets representing political borders:
+Political and administrative boundary datasets:
 \code{\link[=esp_get_capimun]{esp_get_capimun()}},
 \code{\link[=esp_get_ccaa_siane]{esp_get_ccaa_siane()}},
 \code{\link[=esp_get_comarca]{esp_get_comarca()}},
@@ -153,7 +151,7 @@ Other datasets representing political borders:
 \code{\link[=esp_get_spain_siane]{esp_get_spain_siane()}},
 \code{\link[=esp_siane_bulk_download]{esp_siane_bulk_download()}}
 
-Datasets provided by GISCO:
+Datasets sourced from GISCO:
 \code{\link[=esp_get_munic]{esp_get_munic()}},
 \code{\link[=esp_get_nuts]{esp_get_nuts()}},
 \code{\link[=esp_get_prov]{esp_get_prov()}},

--- a/man/esp_get_ccaa_siane.Rd
+++ b/man/esp_get_ccaa_siane.Rd
@@ -122,7 +122,7 @@ ggplot(ccaas_low) +
 \dontshow{\}) # examplesIf}
 }
 \seealso{
-Other datasets representing political borders:
+Political and administrative boundary datasets:
 \code{\link[=esp_get_capimun]{esp_get_capimun()}},
 \code{\link[=esp_get_ccaa]{esp_get_ccaa()}},
 \code{\link[=esp_get_comarca]{esp_get_comarca()}},
@@ -138,7 +138,7 @@ Other datasets representing political borders:
 \code{\link[=esp_get_spain_siane]{esp_get_spain_siane()}},
 \code{\link[=esp_siane_bulk_download]{esp_siane_bulk_download()}}
 
-Political borders from CartoBase ANE:
+Datasets sourced from CartoBase ANE:
 \code{\link[=esp_get_capimun]{esp_get_capimun()}},
 \code{\link[=esp_get_countries_siane]{esp_get_countries_siane()}},
 \code{\link[=esp_get_munic_siane]{esp_get_munic_siane()}},

--- a/man/esp_get_comarca.Rd
+++ b/man/esp_get_comarca.Rd
@@ -3,7 +3,7 @@
 \encoding{UTF-8}
 \name{esp_get_comarca}
 \alias{esp_get_comarca}
-\title{'Comarcas' of Spain}
+\title{Comarcas of Spain}
 \source{
 INE: PC_Axis files, IGN, Ministry of Agriculture, Fisheries and Food (MAPA).
 }
@@ -33,7 +33,7 @@ Initial position can be adjusted using the vector of coordinates. See
 \strong{Displacing the Canary Islands} in \code{\link[=esp_move_can]{esp_move_can()}}.}
 
 \item{type}{Character string. One of \code{"INE"}, \code{"IGN"}, \code{"AGR"}, \code{"LIV"}.
-Type of comarca to return, see \strong{Details}.}
+Type of comarca to return. See \strong{Details}.}
 
 \item{epsg}{Character string or number. Projection of the map: 4-digit
 \href{https://epsg.io/}{EPSG code}. One of:
@@ -78,7 +78,7 @@ in the case of having to answer to third parties due to damages arising
 from such use.
 }
 \section{About comarcas}{
-'Comarcas' (English equivalent: district, county, area or zone) does not
+Comarcas (English equivalent: district, county, area or zone) do not
 always have a formal legal status. They correspond mainly to natural areas
 (valleys, river basins and similar areas), historical regions or ancient
 kingdoms.
@@ -93,7 +93,7 @@ the Principality of Asturias and Andalusia have functional comarcas.
 \code{esp_get_comarca()} can retrieve several types of comarcas, each one
 provided under different classification criteria.
 \itemize{
-\item \code{"INE"}: Comarcas as defined by the National Statistics Institute (INE).
+\item \code{"INE"}: Comarcas defined by the National Statistics Institute (INE).
 \item \code{"IGN"}: Official comarcas, only available in some Autonomous Communities,
 provided by the National Geographic Institute.
 \item \code{"AGR"}: Agrarian comarcas defined by the Ministry of Agriculture,
@@ -101,12 +101,6 @@ Fisheries and Food (MAPA).
 \item \code{"LIV"}: Livestock comarcas defined by the Ministry of Agriculture,
 Fisheries and Food (MAPA).
 }
-}
-
-\section{Note}{
-
-Please check the download and usage provisions on \code{\link[giscoR:gisco_attributions]{gisco_attributions()}}.
-
 }
 
 \examples{
@@ -126,7 +120,7 @@ rec <- esp_get_comarca(type = "IGN")
 ggplot(rec) +
   geom_sf(aes(fill = t_comarca))
 
-# Legal Comarcas of Catalunya
+# Legal comarcas of Catalunya
 
 comarcas_cat <- esp_get_comarca("Catalunya", type = "IGN")
 
@@ -137,7 +131,7 @@ ggplot(comarcas_cat) +
 \dontshow{\}) # examplesIf}
 }
 \seealso{
-Other datasets representing political borders:
+Political and administrative boundary datasets:
 \code{\link[=esp_get_capimun]{esp_get_capimun()}},
 \code{\link[=esp_get_ccaa]{esp_get_ccaa()}},
 \code{\link[=esp_get_ccaa_siane]{esp_get_ccaa_siane()}},

--- a/man/esp_get_countries_siane.Rd
+++ b/man/esp_get_countries_siane.Rd
@@ -3,7 +3,7 @@
 \encoding{UTF-8}
 \name{esp_get_countries_siane}
 \alias{esp_get_countries_siane}
-\title{Countries of the World - SIANE}
+\title{Countries of the world - SIANE}
 \source{
 CartoBase ANE provided by Instituto Geografico Nacional (IGN),
 \url{http://www.ign.es/web/ign/portal}. Years available are 2005 up to today.
@@ -90,7 +90,7 @@ ggplot(cntries) +
 \seealso{
 \code{\link[giscoR:gisco_get_countries]{giscoR::gisco_get_countries()}}.
 
-Other datasets representing political borders:
+Political and administrative boundary datasets:
 \code{\link[=esp_get_capimun]{esp_get_capimun()}},
 \code{\link[=esp_get_ccaa]{esp_get_ccaa()}},
 \code{\link[=esp_get_ccaa_siane]{esp_get_ccaa_siane()}},
@@ -106,7 +106,7 @@ Other datasets representing political borders:
 \code{\link[=esp_get_spain_siane]{esp_get_spain_siane()}},
 \code{\link[=esp_siane_bulk_download]{esp_siane_bulk_download()}}
 
-Political borders from CartoBase ANE:
+Datasets sourced from CartoBase ANE:
 \code{\link[=esp_get_capimun]{esp_get_capimun()}},
 \code{\link[=esp_get_ccaa_siane]{esp_get_ccaa_siane()}},
 \code{\link[=esp_get_munic_siane]{esp_get_munic_siane()}},

--- a/man/esp_get_grid_BDN.Rd
+++ b/man/esp_get_grid_BDN.Rd
@@ -102,7 +102,7 @@ ggplot(grid) +
 \seealso{
 \code{\link[=esp_get_ccaa]{esp_get_ccaa()}}
 
-Other geographical grids:
+Geographical grid datasets:
 \code{\link[=esp_get_grid_ESDAC]{esp_get_grid_ESDAC()}},
 \code{\link[=esp_get_grid_MTN]{esp_get_grid_MTN()}}
 }

--- a/man/esp_get_grid_ESDAC.Rd
+++ b/man/esp_get_grid_ESDAC.Rd
@@ -61,7 +61,7 @@ Commission, Joint Research Centre.
 }
 }
 \seealso{
-Other geographical grids:
+Geographical grid datasets:
 \code{\link[=esp_get_grid_BDN]{esp_get_grid_BDN()}},
 \code{\link[=esp_get_grid_MTN]{esp_get_grid_MTN()}}
 }

--- a/man/esp_get_grid_MTN.Rd
+++ b/man/esp_get_grid_MTN.Rd
@@ -116,7 +116,7 @@ ggplot(grid) +
 \dontshow{\}) # examplesIf}
 }
 \seealso{
-Other geographical grids:
+Geographical grid datasets:
 \code{\link[=esp_get_grid_BDN]{esp_get_grid_BDN()}},
 \code{\link[=esp_get_grid_ESDAC]{esp_get_grid_ESDAC()}}
 }

--- a/man/esp_get_gridmap.Rd
+++ b/man/esp_get_gridmap.Rd
@@ -58,7 +58,7 @@ ggplot(hexccaa) +
   geom_sf(aes(fill = codauto), alpha = 0.3, show.legend = FALSE) +
   geom_sf_text(aes(label = label), check_overlap = TRUE) +
   theme_void() +
-  labs(title = "Hexbin: CCAA")
+  labs(title = "Hexbin: Autonomous Communities")
 
 hexprov <- esp_get_hex_prov()
 
@@ -76,7 +76,7 @@ ggplot(gridccaa) +
   geom_sf(aes(fill = codauto), alpha = 0.3, show.legend = FALSE) +
   geom_sf_text(aes(label = label), check_overlap = TRUE) +
   theme_void() +
-  labs(title = "Grid: CCAA")
+  labs(title = "Grid: Autonomous Communities")
 
 gridprov <- esp_get_grid_prov()
 
@@ -92,7 +92,7 @@ ggplot(gridprov) +
 \seealso{
 \code{\link{esp_get_simpl}}.
 
-Other datasets representing political borders:
+Political and administrative boundary datasets:
 \code{\link[=esp_get_capimun]{esp_get_capimun()}},
 \code{\link[=esp_get_ccaa]{esp_get_ccaa()}},
 \code{\link[=esp_get_ccaa_siane]{esp_get_ccaa_siane()}},

--- a/man/esp_get_hydrobasin.Rd
+++ b/man/esp_get_hydrobasin.Rd
@@ -110,7 +110,7 @@ ggplot(hydroland) +
 \dontshow{\}) # examplesIf}
 }
 \seealso{
-Other natural features:
+Natural feature datasets:
 \code{\link[=esp_get_hypsobath]{esp_get_hypsobath()}},
 \code{\link{esp_get_landwater}}
 }

--- a/man/esp_get_hypsobath.Rd
+++ b/man/esp_get_hypsobath.Rd
@@ -108,7 +108,7 @@ pal <- c(
   tidyterra::hypso.colors(br_terrain, "wiki-2.0_hypso")
 )
 
-# Plot Canary Islands
+# Plot the Canary Islands
 ggplot(hypsobath) +
   geom_sf(aes(fill = as.factor(val_inf)),
     color = NA
@@ -146,7 +146,7 @@ ggplot(hypsobath) +
 \dontshow{\}) # examplesIf}
 }
 \seealso{
-Other natural features:
+Natural feature datasets:
 \code{\link[=esp_get_hydrobasin]{esp_get_hydrobasin()}},
 \code{\link{esp_get_landwater}}
 }

--- a/man/esp_get_landwater.Rd
+++ b/man/esp_get_landwater.Rd
@@ -145,7 +145,7 @@ ggplot(and) +
 \dontshow{\}) # examplesIf}
 }
 \seealso{
-Other natural features:
+Natural feature datasets:
 \code{\link[=esp_get_hydrobasin]{esp_get_hydrobasin()}},
 \code{\link[=esp_get_hypsobath]{esp_get_hypsobath()}}
 }

--- a/man/esp_get_munic.Rd
+++ b/man/esp_get_munic.Rd
@@ -75,15 +75,13 @@ When using \code{region} you can use and mix names and NUTS codes (levels 1, 2 o
 3), ISO codes (corresponding to level 2 or 3) or \code{"cpro"}
 (see \link{esp_codelist}).
 
-When calling a higher level (province, CCAA or NUTS1), all the municipalities
-of that level will be added.
+When calling a higher level (province, Autonomous Community or NUTS1), all
+the municipalities of that level will be added.
 }
-\section{Note}{
-
-Please check the download and usage provisions on \code{\link[giscoR:gisco_attributions]{gisco_attributions()}}.
-
+\note{
+Please check the download and usage provisions on
+\code{\link[giscoR:gisco_attributions]{giscoR::gisco_attributions()}}.
 }
-
 \examples{
 \dontshow{if (esp_check_access()) withAutoprint(\{ # examplesIf}
 \donttest{
@@ -147,7 +145,7 @@ ggplot(spanish_laplad) +
 \seealso{
 \code{\link[giscoR:gisco_get_lau]{giscoR::gisco_get_lau()}}, \code{\link[giscoR:gisco_get_communes]{giscoR::gisco_get_communes()}}.
 
-Other datasets representing political borders:
+Political and administrative boundary datasets:
 \code{\link[=esp_get_capimun]{esp_get_capimun()}},
 \code{\link[=esp_get_ccaa]{esp_get_ccaa()}},
 \code{\link[=esp_get_ccaa_siane]{esp_get_ccaa_siane()}},
@@ -163,11 +161,11 @@ Other datasets representing political borders:
 \code{\link[=esp_get_spain_siane]{esp_get_spain_siane()}},
 \code{\link[=esp_siane_bulk_download]{esp_siane_bulk_download()}}
 
-Datasets representing municipalities:
+Municipality-level datasets:
 \code{\link[=esp_get_capimun]{esp_get_capimun()}},
 \code{\link[=esp_get_munic_siane]{esp_get_munic_siane()}}
 
-Datasets provided by GISCO:
+Datasets sourced from GISCO:
 \code{\link[=esp_get_ccaa]{esp_get_ccaa()}},
 \code{\link[=esp_get_nuts]{esp_get_nuts()}},
 \code{\link[=esp_get_prov]{esp_get_prov()}},

--- a/man/esp_get_munic_siane.Rd
+++ b/man/esp_get_munic_siane.Rd
@@ -102,8 +102,8 @@ When using \code{region} you can use and mix names and NUTS codes (levels 1, 2 o
 3), ISO codes (corresponding to level 2 or 3) or \code{"cpro"}
 (see \link{esp_codelist}).
 
-When calling a higher level (province, CCAA or NUTS1), all the municipalities
-of that level will be added.
+When calling a higher level (province, Autonomous Community or NUTS1), all
+the municipalities of that level will be added.
 }
 \note{
 Although \CRANpkg{mapSpain} supplies cartographically suitable datasets,
@@ -158,7 +158,7 @@ allmunis_unique |>
 \dontshow{\}) # examplesIf}
 }
 \seealso{
-Other datasets representing political borders:
+Political and administrative boundary datasets:
 \code{\link[=esp_get_capimun]{esp_get_capimun()}},
 \code{\link[=esp_get_ccaa]{esp_get_ccaa()}},
 \code{\link[=esp_get_ccaa_siane]{esp_get_ccaa_siane()}},
@@ -174,7 +174,7 @@ Other datasets representing political borders:
 \code{\link[=esp_get_spain_siane]{esp_get_spain_siane()}},
 \code{\link[=esp_siane_bulk_download]{esp_siane_bulk_download()}}
 
-Political borders from CartoBase ANE:
+Datasets sourced from CartoBase ANE:
 \code{\link[=esp_get_capimun]{esp_get_capimun()}},
 \code{\link[=esp_get_ccaa_siane]{esp_get_ccaa_siane()}},
 \code{\link[=esp_get_countries_siane]{esp_get_countries_siane()}},
@@ -182,7 +182,7 @@ Political borders from CartoBase ANE:
 \code{\link[=esp_get_spain_siane]{esp_get_spain_siane()}},
 \code{\link[=esp_siane_bulk_download]{esp_siane_bulk_download()}}
 
-Datasets representing municipalities:
+Municipality-level datasets:
 \code{\link[=esp_get_capimun]{esp_get_capimun()}},
 \code{\link[=esp_get_munic]{esp_get_munic()}}
 }

--- a/man/esp_get_nuts.Rd
+++ b/man/esp_get_nuts.Rd
@@ -106,7 +106,7 @@ The NUTS nomenclature is a hierarchical classification of statistical
 regions and subdivides the EU economic territory into regions of three
 different levels (NUTS 1, 2 and 3, moving respectively from larger to smaller
 territorial units). NUTS 1 is the most aggregated level. An additional
-Country level (NUTS 0) is also available for countries where the nation at
+country level (NUTS 0) is also available for countries where the nation at
 statistical level does not coincide with the administrative boundaries.
 
 The NUTS classification has been officially established through Commission
@@ -114,16 +114,11 @@ Delegated Regulation 2019/1755. A non-official NUTS-like classification has
 been defined for the EFTA countries, candidate countries and potential
 candidates based on a bilateral agreement between Eurostat and the respective
 statistical agencies.
-
-An introduction to the NUTS classification is available here:
-\url{https://ec.europa.eu/eurostat/web/nuts/overview}.
 }
-\section{Note}{
-
-Please check the download and usage provisions on \code{\link[giscoR:gisco_attributions]{gisco_attributions()}}.
-
+\note{
+Please check the download and usage provisions on
+\code{\link[giscoR:gisco_attributions]{giscoR::gisco_attributions()}}.
 }
-
 \examples{
 nuts1 <- esp_get_nuts(nuts_level = 1, moveCAN = TRUE)
 
@@ -179,7 +174,7 @@ ggplot(mixing_codes) +
 \seealso{
 \code{\link[giscoR:gisco_get_nuts]{giscoR::gisco_get_nuts()}}, \code{\link[=esp_dict_region_code]{esp_dict_region_code()}}.
 
-Other datasets representing political borders:
+Political and administrative boundary datasets:
 \code{\link[=esp_get_capimun]{esp_get_capimun()}},
 \code{\link[=esp_get_ccaa]{esp_get_ccaa()}},
 \code{\link[=esp_get_ccaa_siane]{esp_get_ccaa_siane()}},
@@ -195,10 +190,10 @@ Other datasets representing political borders:
 \code{\link[=esp_get_spain_siane]{esp_get_spain_siane()}},
 \code{\link[=esp_siane_bulk_download]{esp_siane_bulk_download()}}
 
-Other nuts:
+NUTS boundary datasets:
 \code{\link[=esp_get_spain]{esp_get_spain()}}
 
-Datasets provided by GISCO:
+Datasets sourced from GISCO:
 \code{\link[=esp_get_ccaa]{esp_get_ccaa()}},
 \code{\link[=esp_get_munic]{esp_get_munic()}},
 \code{\link[=esp_get_prov]{esp_get_prov()}},

--- a/man/esp_get_prov.Rd
+++ b/man/esp_get_prov.Rd
@@ -23,7 +23,7 @@ Initial position can be adjusted using the vector of coordinates. See
 \strong{Displacing the Canary Islands} in \code{\link[=esp_move_can]{esp_move_can()}}.}
 
 \item{...}{
-  Arguments passed on to \code{\link{esp_get_nuts}}, \code{\link{esp_get_nuts}}
+  Arguments passed on to \code{\link{esp_get_nuts}}
   \describe{
     \item{\code{year}}{Year character string or number. Release year of the file. See
 \code{\link[giscoR:gisco_get_nuts]{giscoR::gisco_get_nuts()}} for valid values.}
@@ -79,12 +79,10 @@ Ceuta and Melilla are considered as provinces in this dataset.
 When calling a higher level (Autonomous Community or NUTS1), all the
 provinces of that level will be added.
 }
-\section{Note}{
-
-Please check the download and usage provisions on \code{\link[giscoR:gisco_attributions]{gisco_attributions()}}.
-
+\note{
+Please check the download and usage provisions on
+\code{\link[giscoR:gisco_attributions]{giscoR::gisco_attributions()}}.
 }
-
 \examples{
 prov <- esp_get_prov()
 
@@ -137,7 +135,7 @@ ggplot(allprovs) +
 }
 }
 \seealso{
-Other datasets representing political borders:
+Political and administrative boundary datasets:
 \code{\link[=esp_get_capimun]{esp_get_capimun()}},
 \code{\link[=esp_get_ccaa]{esp_get_ccaa()}},
 \code{\link[=esp_get_ccaa_siane]{esp_get_ccaa_siane()}},
@@ -153,7 +151,7 @@ Other datasets representing political borders:
 \code{\link[=esp_get_spain_siane]{esp_get_spain_siane()}},
 \code{\link[=esp_siane_bulk_download]{esp_siane_bulk_download()}}
 
-Datasets provided by GISCO:
+Datasets sourced from GISCO:
 \code{\link[=esp_get_ccaa]{esp_get_ccaa()}},
 \code{\link[=esp_get_munic]{esp_get_munic()}},
 \code{\link[=esp_get_nuts]{esp_get_nuts()}},

--- a/man/esp_get_prov_siane.Rd
+++ b/man/esp_get_prov_siane.Rd
@@ -115,7 +115,7 @@ esp_get_ccaa_siane() |>
 \dontshow{\}) # examplesIf}
 }
 \seealso{
-Other datasets representing political borders:
+Political and administrative boundary datasets:
 \code{\link[=esp_get_capimun]{esp_get_capimun()}},
 \code{\link[=esp_get_ccaa]{esp_get_ccaa()}},
 \code{\link[=esp_get_ccaa_siane]{esp_get_ccaa_siane()}},
@@ -131,7 +131,7 @@ Other datasets representing political borders:
 \code{\link[=esp_get_spain_siane]{esp_get_spain_siane()}},
 \code{\link[=esp_siane_bulk_download]{esp_siane_bulk_download()}}
 
-Political borders from CartoBase ANE:
+Datasets sourced from CartoBase ANE:
 \code{\link[=esp_get_capimun]{esp_get_capimun()}},
 \code{\link[=esp_get_ccaa_siane]{esp_get_ccaa_siane()}},
 \code{\link[=esp_get_countries_siane]{esp_get_countries_siane()}},

--- a/man/esp_get_railway.Rd
+++ b/man/esp_get_railway.Rd
@@ -117,7 +117,7 @@ ggplot(provs) +
 \dontshow{\}) # examplesIf}
 }
 \seealso{
-Other man-made infrastructures:
+Transport infrastructure datasets:
 \code{\link[=esp_get_roads]{esp_get_roads()}}
 }
 \concept{infrastructure}

--- a/man/esp_get_roads.Rd
+++ b/man/esp_get_roads.Rd
@@ -96,7 +96,7 @@ ggplot(country) +
 \dontshow{\}) # examplesIf}
 }
 \seealso{
-Other man-made infrastructures:
+Transport infrastructure datasets:
 \code{\link[=esp_get_railway]{esp_get_railway()}}
 }
 \concept{infrastructure}

--- a/man/esp_get_simpl.Rd
+++ b/man/esp_get_simpl.Rd
@@ -64,16 +64,16 @@ library(ggplot2)
 
 ggplot(prov_simp) +
   geom_sf(aes(fill = ine.ccaa.name)) +
-  labs(fill = "CCAA")
+  labs(fill = "Autonomous Communities")
 
-# Provinces of a single CCAA.
+# Provinces of a single Autonomous Community.
 
 and_simple <- esp_get_simpl_prov("Andalucia")
 
 ggplot(and_simple) +
   geom_sf()
 
-# CCAAs.
+# Autonomous Communities.
 
 ccaa_simp <- esp_get_simpl_ccaa()
 
@@ -86,7 +86,7 @@ ggplot(ccaa_simp) +
 \seealso{
 \code{\link{esp_get_gridmap}}.
 
-Other datasets representing political borders:
+Political and administrative boundary datasets:
 \code{\link[=esp_get_capimun]{esp_get_capimun()}},
 \code{\link[=esp_get_ccaa]{esp_get_ccaa()}},
 \code{\link[=esp_get_ccaa_siane]{esp_get_ccaa_siane()}},

--- a/man/esp_get_spain.Rd
+++ b/man/esp_get_spain.Rd
@@ -64,12 +64,10 @@ specified scale.
 Dataset derived from NUTS data provided by GISCO. Check \code{\link[=esp_get_nuts]{esp_get_nuts()}} for
 details.
 }
-\section{Note}{
-
-Please check the download and usage provisions on \code{\link[giscoR:gisco_attributions]{gisco_attributions()}}.
-
+\note{
+Please check the download and usage provisions on
+\code{\link[giscoR:gisco_attributions]{giscoR::gisco_attributions()}}.
 }
-
 \examples{
 \dontshow{if (esp_check_access()) withAutoprint(\{ # examplesIf}
 \donttest{
@@ -92,7 +90,7 @@ ggplot(moved_can) +
 \dontshow{\}) # examplesIf}
 }
 \seealso{
-Other datasets representing political borders:
+Political and administrative boundary datasets:
 \code{\link[=esp_get_capimun]{esp_get_capimun()}},
 \code{\link[=esp_get_ccaa]{esp_get_ccaa()}},
 \code{\link[=esp_get_ccaa_siane]{esp_get_ccaa_siane()}},
@@ -108,10 +106,10 @@ Other datasets representing political borders:
 \code{\link[=esp_get_spain_siane]{esp_get_spain_siane()}},
 \code{\link[=esp_siane_bulk_download]{esp_siane_bulk_download()}}
 
-Other nuts:
+NUTS boundary datasets:
 \code{\link[=esp_get_nuts]{esp_get_nuts()}}
 
-Datasets provided by GISCO:
+Datasets sourced from GISCO:
 \code{\link[=esp_get_ccaa]{esp_get_ccaa()}},
 \code{\link[=esp_get_munic]{esp_get_munic()}},
 \code{\link[=esp_get_nuts]{esp_get_nuts()}},

--- a/man/esp_get_spain_siane.Rd
+++ b/man/esp_get_spain_siane.Rd
@@ -95,7 +95,7 @@ ggplot(moved_can) +
 \dontshow{\}) # examplesIf}
 }
 \seealso{
-Other datasets representing political borders:
+Political and administrative boundary datasets:
 \code{\link[=esp_get_capimun]{esp_get_capimun()}},
 \code{\link[=esp_get_ccaa]{esp_get_ccaa()}},
 \code{\link[=esp_get_ccaa_siane]{esp_get_ccaa_siane()}},
@@ -111,7 +111,7 @@ Other datasets representing political borders:
 \code{\link[=esp_get_spain]{esp_get_spain()}},
 \code{\link[=esp_siane_bulk_download]{esp_siane_bulk_download()}}
 
-Political borders from CartoBase ANE:
+Datasets sourced from CartoBase ANE:
 \code{\link[=esp_get_capimun]{esp_get_capimun()}},
 \code{\link[=esp_get_ccaa_siane]{esp_get_ccaa_siane()}},
 \code{\link[=esp_get_countries_siane]{esp_get_countries_siane()}},

--- a/man/esp_get_tiles.Rd
+++ b/man/esp_get_tiles.Rd
@@ -171,7 +171,7 @@ autoplot(cartodb_dark_tile, maxcell = Inf) +
 
 \code{\link[giscoR:gisco_attributions]{giscoR::gisco_attributions()}}
 
-Other functions for creating maps with images:
+Functions for image-based maps and tile providers:
 \code{\link[=addProviderEspTiles]{addProviderEspTiles()}},
 \code{\link[=esp_make_provider]{esp_make_provider()}}
 }

--- a/man/esp_make_provider.Rd
+++ b/man/esp_make_provider.Rd
@@ -63,7 +63,7 @@ tidyterra::autoplot(mytile) +
 For a list of potential providers from Spain check
 \href{https://www.idee.es/segun-tipo-de-servicio}{IDEE Directory}.
 
-Other functions for creating maps with images:
+Functions for image-based maps and tile providers:
 \code{\link[=addProviderEspTiles]{addProviderEspTiles()}},
 \code{\link[=esp_get_tiles]{esp_get_tiles()}}
 }

--- a/man/esp_move_can.Rd
+++ b/man/esp_move_can.Rd
@@ -74,7 +74,7 @@ ggplot(esp) +
 
 }
 \seealso{
-Other helpers for the Canary Islands:
+Helpers for Canary Islands insets and displacement:
 \code{\link[=esp_get_can_box]{esp_get_can_box()}}
 }
 \concept{can_helpers}

--- a/man/esp_nuts_2024.Rd
+++ b/man/esp_nuts_2024.Rd
@@ -11,10 +11,10 @@ resolution in \href{https://epsg.io/4258}{EPSG:4258} projection, containing
 86 rows and 10 variables:
 \describe{
 \item{\code{NUTS_ID}}{NUTS identifier.}
-\item{\code{LEVL_CODE}}{NUTS level code \verb{(0,1,2,3)}.}
+\item{\code{LEVL_CODE}}{NUTS level code \verb{(0, 1, 2, 3)}.}
 \item{\code{CNTR_CODE}}{Eurostat country code.}
-\item{\code{NAME_LATN}}{NUTS name on Latin characters.}
-\item{\code{NUTS_NAME}}{NUTS name on local alphabet.}
+\item{\code{NAME_LATN}}{NUTS name in Latin characters.}
+\item{\code{NUTS_NAME}}{NUTS name in the local alphabet.}
 \item{\code{MOUNT_TYPE}}{Mountain type, see \strong{Details}.}
 \item{\code{URBN_TYPE}}{Urban type, see \strong{Details}.}
 \item{\code{COAST_TYPE}}{Coastal type, see \strong{Details}.}
@@ -70,7 +70,7 @@ head(esp_nuts_2024)
 \seealso{
 \code{\link[=esp_get_nuts]{esp_get_nuts()}}
 
-Other datasets:
+Included package datasets:
 \code{\link{esp_codelist}},
 \code{\link{esp_tiles_providers}},
 \code{\link{pobmun25}}

--- a/man/esp_set_cache_dir.Rd
+++ b/man/esp_set_cache_dir.Rd
@@ -104,7 +104,7 @@ esp_detect_cache_dir()
 \seealso{
 \code{\link[tools:R_user_dir]{tools::R_user_dir()}}
 
-Other cache utilities:
+Cache management utilities:
 \code{\link[=esp_clear_cache]{esp_clear_cache()}}
 }
 \concept{cache utilities}

--- a/man/esp_siane_bulk_download.Rd
+++ b/man/esp_siane_bulk_download.Rd
@@ -72,7 +72,7 @@ unlink(tmp, force = TRUE, recursive = TRUE)
 \dontshow{\}) # examplesIf}
 }
 \seealso{
-Other datasets representing political borders:
+Political and administrative boundary datasets:
 \code{\link[=esp_get_capimun]{esp_get_capimun()}},
 \code{\link[=esp_get_ccaa]{esp_get_ccaa()}},
 \code{\link[=esp_get_ccaa_siane]{esp_get_ccaa_siane()}},
@@ -88,7 +88,7 @@ Other datasets representing political borders:
 \code{\link[=esp_get_spain]{esp_get_spain()}},
 \code{\link[=esp_get_spain_siane]{esp_get_spain_siane()}}
 
-Political borders from CartoBase ANE:
+Datasets sourced from CartoBase ANE:
 \code{\link[=esp_get_capimun]{esp_get_capimun()}},
 \code{\link[=esp_get_ccaa_siane]{esp_get_ccaa_siane()}},
 \code{\link[=esp_get_countries_siane]{esp_get_countries_siane()}},

--- a/man/esp_tiles_providers.Rd
+++ b/man/esp_tiles_providers.Rd
@@ -150,7 +150,7 @@ single$leaflet
 
 }
 \seealso{
-Other datasets:
+Included package datasets:
 \code{\link{esp_codelist}},
 \code{\link{esp_nuts_2024}},
 \code{\link{pobmun25}}

--- a/man/mapSpain-package.Rd
+++ b/man/mapSpain-package.Rd
@@ -8,7 +8,7 @@
 \description{
 \if{html}{\figure{logo.png}{options: style='float: right' alt='logo' width='120'}}
 
-Administrative boundaries of Spain at several levels (Autonomous Communities, provinces and municipalities), based on 'GISCO' from 'Eurostat' \url{https://ec.europa.eu/eurostat/web/gisco} and 'CartoBase ANE' from 'Instituto Geográfico Nacional' \url{https://www.ign.es/}. It also provides a plugin for 'leaflet' and tools to download and process static map tiles.
+Administrative boundaries of Spain at several levels (Autonomous Communities, provinces and municipalities), based on 'GISCO' from 'Eurostat' \url{https://ec.europa.eu/eurostat/web/gisco} and 'CartoBase ANE' from 'Instituto Geográfico Nacional' \url{https://www.ign.es/}. It also provides a plugin for the 'leaflet' package and tools to download and process static map tiles.
 }
 \seealso{
 Useful links:

--- a/man/pobmun25.Rd
+++ b/man/pobmun25.Rd
@@ -31,7 +31,7 @@ Population of Spain by municipality (2025)
 data("pobmun25")
 }
 \seealso{
-Other datasets:
+Included package datasets:
 \code{\link{esp_codelist}},
 \code{\link{esp_nuts_2024}},
 \code{\link{esp_tiles_providers}}

--- a/man/roxygen/meta.R
+++ b/man/roxygen/meta.R
@@ -1,13 +1,18 @@
 list(
   rd_family_title = list(
-    images = "Other functions for creating maps with images: ",
-    can_helpers = "Other helpers for the Canary Islands: ",
-    political = "Other datasets representing political borders: ",
-    siane = "Political borders from CartoBase ANE: ",
-    gisco = "Datasets provided by GISCO: ",
-    municipalities = "Datasets representing municipalities: ",
-    grids = "Other geographical grids: ",
-    natural = "Other natural features: ",
-    infrastructure = "Other man-made infrastructures: "
+    images = "Functions for image-based maps and tile providers: ",
+    can_helpers = "Helpers for Canary Islands insets and displacement: ",
+    political = "Political and administrative boundary datasets: ",
+    siane = "Datasets sourced from CartoBase ANE: ",
+    gisco = "Datasets sourced from GISCO: ",
+    municipalities = "Municipality-level datasets: ",
+    grids = "Geographical grid datasets: ",
+    natural = "Natural feature datasets: ",
+    infrastructure = "Transport infrastructure datasets: ",
+    datasets = "Included package datasets: ",
+    dictionary = "Dictionary and translation helpers: ",
+    nuts = "NUTS boundary datasets: ",
+    "cache utilities" = "Cache management utilities: ",
+    "deprecated functions" = "Deprecated functions: "
   )
 )

--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -63,15 +63,15 @@ home:
   description: |
     Administrative boundaries of Spain based on GISCO (Geographic Information
     System of the Commission) from Eurostat and CartoBase ANE from Instituto
-    Geográfico Nacional. It also provides a plugin for leaflet and tools to
-    download and process static map tiles.
+    Geográfico Nacional. It also provides a plugin for the leaflet package and
+    tools to download and process static map tiles.
 
 reference:
-- title: Political boundaries of Spain
+- title: Political and administrative boundaries
   desc: |
     These functions return <a href="https://CRAN.R-project.org/package=sf"
     class="external-link"><span class="pkg">sf</span></a> objects representing
-    political boundaries.
+    political and administrative boundaries.
 - subtitle: CartoBase ANE
   description: |
     Datasets from IGN and CartoBase ANE.
@@ -82,7 +82,7 @@ reference:
     Datasets from GISCO and Eurostat.
   contents:
   - has_concept("gisco")
-- subtitle: Other helpers and political objects
+- subtitle: Additional boundary helpers
   contents:
   - has_concept("can_helpers")
   - esp_get_comarca
@@ -105,11 +105,11 @@ reference:
     features.
   contents:
   - has_concept("natural")
-- title: Infrastructure
+- title: Transport infrastructure
   desc: |
     These functions return <a href="https://CRAN.R-project.org/package=sf"
     class="external-link"><span class="pkg">sf</span></a> objects with
-    infrastructure features.
+    transport infrastructure features.
   contents:
   - has_concept("infrastructure")
 - title: Cache management

--- a/tests/testthat/_snaps/esp-get-ccaa-siane.md
+++ b/tests/testthat/_snaps/esp-get-ccaa-siane.md
@@ -4,7 +4,7 @@
       esp_get_ccaa_siane(ccaa = "Menorca", cache_dir = cdir)
     Condition
       Error in `convert_to_nuts_ccaa()`:
-      ! No Spanish CCAA codes found for "Menorca".
+      ! No Spanish Autonomous Communities codes found for "Menorca".
 
 ---
 
@@ -12,5 +12,5 @@
       esp_get_ccaa_siane(ccaa = "ES6x", cache_dir = cdir)
     Condition
       Error in `convert_to_nuts_ccaa()`:
-      ! No Spanish CCAA codes found for "ES6x".
+      ! No Spanish Autonomous Communities codes found for "ES6x".
 

--- a/tests/testthat/_snaps/esp-get-ccaa.md
+++ b/tests/testthat/_snaps/esp-get-ccaa.md
@@ -4,14 +4,14 @@
       esp_get_ccaa("FFF")
     Condition
       Error in `convert_to_nuts_ccaa()`:
-      ! No Spanish CCAA codes found for "FFF".
+      ! No Spanish Autonomous Communities codes found for "FFF".
 
 ---
 
     Code
       n <- esp_get_ccaa(c("FFF", "Murcia"))
     Message
-      ! No Spanish CCAA codes found for "FFF".
+      ! No Spanish Autonomous Communities codes found for "FFF".
 
 ---
 
@@ -19,7 +19,7 @@
       esp_get_ccaa(ccaa = "Zamora")
     Condition
       Error in `convert_to_nuts_ccaa()`:
-      ! No Spanish CCAA codes found for "Zamora".
+      ! No Spanish Autonomous Communities codes found for "Zamora".
 
 ---
 
@@ -27,5 +27,5 @@
       esp_get_ccaa(ccaa = "ES6x")
     Condition
       Error in `convert_to_nuts_ccaa()`:
-      ! No Spanish CCAA codes found for "ES6x".
+      ! No Spanish Autonomous Communities codes found for "ES6x".
 

--- a/tests/testthat/_snaps/esp-get-grid-BDN.md
+++ b/tests/testthat/_snaps/esp-get-grid-BDN.md
@@ -20,7 +20,7 @@
       esp_get_grid_BDN_ccaa("Sevilla")
     Condition
       Error in `convert_to_nuts_ccaa()`:
-      ! No Spanish CCAA codes found for "Sevilla".
+      ! No Spanish Autonomous Communities codes found for "Sevilla".
 
 ---
 

--- a/tests/testthat/_snaps/esp-get-gridmap.md
+++ b/tests/testthat/_snaps/esp-get-gridmap.md
@@ -12,5 +12,5 @@
       esp_get_grid_ccaa("Mallorca")
     Condition
       Error in `convert_to_nuts_ccaa()`:
-      ! No Spanish CCAA codes found for "Mallorca".
+      ! No Spanish Autonomous Communities codes found for "Mallorca".
 

--- a/tests/testthat/_snaps/esp-get-landwater.md
+++ b/tests/testthat/_snaps/esp-get-landwater.md
@@ -32,5 +32,5 @@
       The `spatialtype` argument of `esp_get_rivers()` is deprecated as of mapSpain 1.0.0.
       i Please use `esp_get_wetlands()` instead.
     Message
-      i Redirecting the arguments to `mapSpain::esp_get_wetlands()`
+      i Redirecting the arguments to `mapSpain::esp_get_wetlands()`.
 

--- a/tests/testthat/_snaps/esp-get-simpl.md
+++ b/tests/testthat/_snaps/esp-get-simpl.md
@@ -12,5 +12,5 @@
       esp_get_simpl_ccaa("Mallorca", cache_dir = cdir)
     Condition
       Error in `convert_to_nuts_ccaa()`:
-      ! No Spanish CCAA codes found for "Mallorca".
+      ! No Spanish Autonomous Communities codes found for "Mallorca".
 

--- a/tests/testthat/_snaps/esp-get-tiles.md
+++ b/tests/testthat/_snaps/esp-get-tiles.md
@@ -11,8 +11,8 @@
     Code
       esp_get_tiles(ff, type = "IGNBase", options = list(format = "image/aabbcc"))
     Condition
-      Error:
-      ! `prov_ext` should be one of "png", "jpeg", "jpg", "tiff" or "geotiff", not "aabbcc".
+      Error in `validate_tile_ext()`:
+      ! The requested file extension should be one of "png", "jpeg", "jpg", "tiff" or "geotiff", not "aabbcc".
 
 # WMTS
 

--- a/tests/testthat/_snaps/utils-convert-names.md
+++ b/tests/testthat/_snaps/utils-convert-names.md
@@ -57,7 +57,7 @@
     Code
       convert_to_nuts_ccaa(c("Asturies", "Zaporilla", "ES1", "ES-CL"))
     Message
-      ! No Spanish CCAA codes found for "Zaporilla".
+      ! No Spanish Autonomous Communities codes found for "Zaporilla".
     Output
       [1] "ES11" "ES12" "ES13" "ES41"
 
@@ -67,7 +67,7 @@
       convert_to_nuts_ccaa(c("Aama", "ES888", "FR12", "ES9"))
     Condition
       Error in `convert_to_nuts_ccaa()`:
-      ! No Spanish CCAA codes found for "Aama", "ES888", "FR12", and "ES9".
+      ! No Spanish Autonomous Communities codes found for "Aama", "ES888", "FR12", and "ES9".
 
 ---
 
@@ -90,7 +90,7 @@
     Code
       convert_to_nuts_ccaa(c("Murcia", "Almeria"))
     Message
-      ! No Spanish CCAA codes found for "Almeria".
+      ! No Spanish Autonomous Communities codes found for "Almeria".
     Output
       [1] "ES62"
 
@@ -100,7 +100,7 @@
       convert_to_nuts_ccaa(c("La Gomera", "Almeria", "Soria"))
     Condition
       Error in `convert_to_nuts_ccaa()`:
-      ! No Spanish CCAA codes found for "La Gomera", "Almeria", and "Soria".
+      ! No Spanish Autonomous Communities codes found for "La Gomera", "Almeria", and "Soria".
 
 ---
 
@@ -108,7 +108,7 @@
       convert_to_nuts_ccaa(c("AA", "XX"))
     Condition
       Error in `convert_to_nuts_ccaa()`:
-      ! No Spanish CCAA codes found for "AA" and "XX".
+      ! No Spanish Autonomous Communities codes found for "AA" and "XX".
 
 # convert_to_nuts_prov
 

--- a/tests/testthat/_snaps/utils-sf.md
+++ b/tests/testthat/_snaps/utils-sf.md
@@ -6,5 +6,5 @@
       ! Cannot read file '<path>'.
     Condition
       Error in `read_geo_file_sf()`:
-      ! Please open an issue: <https://github.com/rOpenSpain/mapSpain/issues>.
+      ! Please open an issue at <https://github.com/rOpenSpain/mapSpain/issues>.
 

--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -1,0 +1,29 @@
+skip_if_siane_offline <- function() {
+  test_offline <- is_404()
+  if (test_offline) {
+    return(invisible(TRUE))
+  }
+
+  if (esp_check_access()) {
+    return(invisible(TRUE))
+  }
+
+  testthat::skip("SIANE API not reachable")
+
+  invisible()
+}
+
+skip_if_gisco_offline <- function() {
+  test_offline <- is_404()
+  if (test_offline) {
+    return(invisible(TRUE))
+  }
+
+  if (giscoR::gisco_check_access()) {
+    return(invisible(TRUE))
+  }
+
+  testthat::skip("GISCO API not reachable")
+
+  invisible()
+}

--- a/tests/testthat/test-utils-dict.R
+++ b/tests/testthat/test-utils-dict.R
@@ -72,3 +72,9 @@ test_that("Get codes", {
   expect_snapshot(var[!cpro == "XX"])
   expect_snapshot(var[cpro == "XX"])
 })
+
+test_that("Region filters return input for NULL selections", {
+  x <- data.frame(codauto = c("01", "02"), cpro = c("04", "03"))
+
+  expect_identical(filter_by_codauto_region(x, NULL), x)
+})

--- a/tests/testthat/test-utils-url.R
+++ b/tests/testthat/test-utils-url.R
@@ -199,7 +199,7 @@ test_that("Test timeout", {
   withr::local_options(mapspain_timeout = 0.01)
   expect_error(
     download_url(url = url, verbose = FALSE, cache_dir = cdir),
-    "Failed to perform HTTP request(.*)Timeout(.*)after(.*)milliseconds"
+    "Failed to perform HTTP request(.*)Timeout"
   )
 
   withr::local_options(mapspain_timeout = 300L)

--- a/tests/testthat/test-utils-url.R
+++ b/tests/testthat/test-utils-url.R
@@ -169,7 +169,7 @@ test_that("Caching errors", {
       update_cache = FALSE,
       verbose = FALSE
     ),
-    "The file to be downloaded has size"
+    "The download size"
   )
 
   unlink(cdir, recursive = TRUE, force = TRUE)

--- a/vignettes/articles/mapasesp.qmd
+++ b/vignettes/articles/mapasesp.qmd
@@ -29,9 +29,9 @@ knitr:
 It also supports imagery from WMS and WMTS services, either as georeferenced
 static rasters or as dynamic layers in Leaflet maps.
 
-The package also includes helpers to normalize Autonomous Community and province
-names. These helpers make it easier to join, clean and transform data, whether
-or not the data is spatial.
+The package also includes helpers to normalize Autonomous Community and
+province names. These helpers make it easier to join, clean and transform data,
+whether or not the data is spatial.
 
 The main data sources used by **mapSpain** are:
 
@@ -41,8 +41,8 @@ The main data sources used by **mapSpain** are:
 - Spanish public institutions that publish WMTS and WMS tile services
   (<https://www.idee.es/web/idee/segun-tipo-de-servicio>).
 
-The returned objects are `sf` objects from the **sf** package or `SpatRaster`
-objects from the **terra** package.
+Functions return `sf` objects from the **sf** package or `SpatRaster` objects
+from the **terra** package.
 
 Package website: <https://ropenspain.github.io/mapSpain/>.
 
@@ -121,7 +121,7 @@ reactable(
 ### Comparing mapSpain with other alternatives
 
 The next example compares **mapSpain** with other packages that provide `sf` or
-`SpatVector` objects for country boundaries:
+`SpatVector` objects for country boundaries.
 
 ```{r}
 #| label: fig-compara
@@ -195,8 +195,8 @@ ggplot(esp_all) +
 
 ### Caching
 
-**mapSpain** is an API package that uses web resources. By default, downloaded
-files are stored in `tempdir()` for reuse during the current session.
+**mapSpain** uses web resources. By default, downloaded files are stored in
+`tempdir()` for reuse during the current session.
 
 Use `esp_set_cache_dir()` to choose a user-specific download directory. Add
 `install = TRUE` to make that cache configuration persistent across sessions.
@@ -282,9 +282,9 @@ levels:
 - Provinces.
 - Municipalities.
 
-For Autonomous Communities, provinces and municipalities there are two families
-of functions: `esp_get_xxxx()` (GISCO source) and `esp_get_xxxx_siane()` (IGN
-source).
+For Autonomous Communities, provinces and municipalities, there are two
+families of functions: `esp_get_xxxx()` for GISCO data and
+`esp_get_xxxx_siane()` for IGN data.
 
 The information is available in different projections and resolution levels.
 
@@ -524,7 +524,7 @@ ggplot() +
 
 ### Dynamic maps with mapSpain
 
-Imagery layers can be used as backgrounds in interactive maps and static maps.
+Imagery layers can be used as backgrounds in static and interactive maps.
 
 ```{r}
 #| label: leaflet
@@ -568,5 +568,5 @@ leaflet(stations, elementId = "railway", width = "100%", height = "60vh") |>
 [functions](https://ropenspain.github.io/mapSpain/reference/index.html#section-natural)
 for retrieving elevation, rivers and river basin data for Spain, as well as
 Spanish
-[infrastructure](https://ropenspain.github.io/mapSpain/reference/index.html#section-infrastructures)
+[transport infrastructure](https://ropenspain.github.io/mapSpain/reference/index.html#section-transport-infrastructure)
 lines and points, such as roads and railway lines.

--- a/vignettes/articles/regioncodes.qmd
+++ b/vignettes/articles/regioncodes.qmd
@@ -14,8 +14,8 @@ knitr:
 ---
 
 This appendix shows an interactive version of the `mapSpain::esp_codelist`
-data frame. That dataset contains Spanish region codes under different schemes
-and naming versions in several languages.
+data frame. The dataset contains Spanish region codes under different schemes
+and naming variants in several languages.
 
 ## Names and codes of Spanish regions
 

--- a/vignettes/articles/working_imagery.qmd
+++ b/vignettes/articles/working_imagery.qmd
@@ -16,17 +16,17 @@ knitr:
     out.width: "100%"
 ---
 
-**mapSpain** provides an interface for working with imagery. It can
-download static files as `.png` or `.jpeg` (depending on the Web Map Service)
-and use them alongside your shapefiles.
+**mapSpain** provides an interface for working with imagery. It can download
+static files as `.png` or `.jpeg`, depending on the Web Map Service, and use
+them alongside your `sf` objects.
 
-**mapSpain** also provides a plugin for the **R**
-[**leaflet**](https://rstudio.github.io/leaflet/) package, which allows adding
+**mapSpain** also provides a plugin for the
+[**leaflet**](https://rstudio.github.io/leaflet/) R package, which allows adding
 multiple basemaps to interactive maps.
 
 The services are implemented with the Leaflet plugin
 [leaflet-providersESP](https://dieghernan.github.io/leaflet-providersESP/). You
-can view each provider option at that link.
+can view the available provider options at that link.
 
 ## Static tiles
 
@@ -35,8 +35,8 @@ layers provided by La Rioja's [Infraestructura de Datos Espaciales
 (IDERioja)](https://www.iderioja.larioja.org/).
 
 ::: callout-warning
-When working with imagery, set `moveCAN = FALSE` because otherwise images for
-the Canary Islands may be inaccurate.
+When working with imagery, set `moveCAN = FALSE`, otherwise imagery for the
+Canary Islands may be inaccurate.
 :::
 
 ```{r}
@@ -123,7 +123,7 @@ Another useful feature is tile masking, which supports more advanced maps:
 
 ```{r}
 #| label: fig-static3
-#| fig-cap: Example of combining tile types by masking to a shapefile.
+#| fig-cap: Example of combining tile types by masking to an sf object.
 rioja <- esp_get_prov("La Rioja", epsg = 3857)
 
 basemap <- esp_get_tiles(rioja, "PNOA", bbox_expand = 0.1, zoommin = 1)
@@ -138,7 +138,7 @@ ggplot() +
 ## Custom providers
 
 You can use `esp_get_tiles()` to get tiles from other providers, for example
-OpenStreetMap:
+OpenStreetMap.
 
 ```{r}
 #| label: fig-osm
@@ -156,7 +156,7 @@ ggplot() +
   geom_sf(data = madrid_city, fill = NA)
 ```
 
-Another example using a provider that needs an API key (ThunderForest):
+This example uses a provider that needs an API key, ThunderForest:
 
 ```{r}
 #| label: fig-thunder
@@ -237,7 +237,7 @@ munic <- esp_get_munic_siane(
   rawcols = TRUE
 ) |>
   # Get area in km2 from SIANE municipalities.
-  # This variable is already in the shapefile.
+  # This variable is already available in the SIANE data.
   mutate(area_km2 = st_area_sh * 10000)
 
 # Get population data.

--- a/vignettes/imagery.qmd
+++ b/vignettes/imagery.qmd
@@ -7,7 +7,7 @@ vignette: >
 ---
 
 Visit <https://ropenspain.github.io/mapSpain/articles/working_imagery.html> to
-learn how to download imagery for Spain.
+learn how to download and use imagery for Spain.
 
 ::: callout-note
 You may need several additional packages. Install them by running:

--- a/vignettes/mapSpain.qmd
+++ b/vignettes/mapSpain.qmd
@@ -21,17 +21,17 @@ For more examples and vignettes, see the full site at
 <https://ropenspain.github.io/mapSpain/>.
 :::
 
-[**mapSpain**](https://ropenspain.github.io/mapSpain/) is a package designed to
-provide geographical information about Spain at different levels.
+[**mapSpain**](https://ropenspain.github.io/mapSpain/) provides geographical
+information about Spain at different levels.
 
-**mapSpain** provides shapefiles of municipalities, provinces, Autonomous
-communities and NUTS levels for Spain. It also provides hexbin shapefiles and
-other complementary shapes, such as the demarcation lines around the Canary
+**mapSpain** provides `sf` objects for municipalities, provinces, Autonomous
+Communities and NUTS levels in Spain. It also provides hexbin maps and other
+complementary geometries, such as the demarcation lines around the Canary
 Islands.
 
-**mapSpain** provides access to map tiles from Spain's public institutions,
-which can be represented on static maps via `mapSpain::esp_get_tiles()` or on an
-**R** [**leaflet**](https://rstudio.github.io/leaflet/) map using
+**mapSpain** provides access to map tiles from Spain's public institutions.
+Tiles can be represented on static maps with `mapSpain::esp_get_tiles()` or on
+an R [**leaflet**](https://rstudio.github.io/leaflet/) map using
 `mapSpain::addProviderEspTiles()`.
 
 **mapSpain** also includes a dictionary that translates province and region
@@ -41,8 +41,7 @@ statistical agency) coding system.
 
 ## Caching
 
-**mapSpain** provides dataset and tile caching capabilities. Set a cache
-directory with:
+**mapSpain** provides dataset and tile caching. Set a cache directory with:
 
 
 ``` r
@@ -50,13 +49,12 @@ esp_set_cache_dir("./path/to/location")
 ```
 
 **mapSpain** relies on [**giscoR**](https://ropengov.github.io/giscoR/) for
-downloading certain files, and both packages are well synchronized. Setting the
-same caching directory for both packages will speed up data loading in your
-session.
+downloading some files, and both packages can share cache settings. Using the
+same cache directory for both packages speeds up data loading in your session.
 
 ## Basic example
 
-These examples show what **mapSpain** can do:
+These examples show key **mapSpain** workflows:
 
 
 ``` r
@@ -147,14 +145,14 @@ library(dplyr)
 census <- mapSpain::pobmun25 |>
   select(-name)
 
-# Extract CCAA from the base dataset.
+# Extract Autonomous Community codes from the base dataset.
 codelist <- mapSpain::esp_codelist |>
   select(cpro, codauto) |>
   distinct()
 
 census_ccaa <- census |>
   left_join(codelist) |>
-  # Summarize by CCAA.
+  # Summarize by Autonomous Community.
   group_by(codauto) |>
   summarise(pob25 = sum(pob25), men = sum(men), women = sum(women)) |>
   mutate(
@@ -214,7 +212,7 @@ pop <- mapSpain::pobmun25 |>
 
 munic <- esp_get_munic_siane(rawcols = TRUE) |>
   # Get area in km2 from SIANE municipalities.
-  # This variable is already in the shapefile.
+  # This variable is already available in the SIANE data.
   mutate(area_km2 = st_area_sh * 10000)
 
 munic_pop <- munic |>
@@ -257,9 +255,9 @@ ggplot(munic_pop) +
 
 ## mapSpain and giscoR
 
-If you need to plot Spain alongside other countries, consider using the
+If you need to plot Spain alongside other countries, use the
 [**giscoR**](https://ropengov.github.io/giscoR/) package, which is installed as
-a dependency with **mapSpain**. Here is a basic example:
+a dependency of **mapSpain**. Here is a basic example:
 
 
 ``` r
@@ -310,13 +308,13 @@ ggplot(all_countries) +
 
 ## Working with tiles
 
-**mapSpain** provides a powerful interface for working with imagery. It can
-download static images as `.png` or `.jpeg` (depending on the Web Map Service)
-and use them alongside your shapefiles.
+**mapSpain** provides an interface for working with imagery. It can download
+static images as `.png` or `.jpeg`, depending on the Web Map Service, and use
+them alongside your `sf` objects.
 
-**mapSpain** also includes a plugin for the **R**
-[**leaflet**](https://rstudio.github.io/leaflet/) package, which allows you to
-include several basemaps on your interactive maps.
+**mapSpain** also includes a plugin for the
+[**leaflet**](https://rstudio.github.io/leaflet/) R package, which allows you to
+add several basemaps to interactive maps.
 
 The services are implemented with the
 [leaflet-providersESP](https://dieghernan.github.io/leaflet-providersESP/)

--- a/vignettes/mapSpain.qmd.orig
+++ b/vignettes/mapSpain.qmd.orig
@@ -35,17 +35,17 @@ For more examples and vignettes, see the full site at
 <https://ropenspain.github.io/mapSpain/>.
 :::
 
-[**mapSpain**](https://ropenspain.github.io/mapSpain/) is a package designed to
-provide geographical information about Spain at different levels.
+[**mapSpain**](https://ropenspain.github.io/mapSpain/) provides geographical
+information about Spain at different levels.
 
-**mapSpain** provides shapefiles of municipalities, provinces, Autonomous
-communities and NUTS levels for Spain. It also provides hexbin shapefiles and
-other complementary shapes, such as the demarcation lines around the Canary
+**mapSpain** provides `sf` objects for municipalities, provinces, Autonomous
+Communities and NUTS levels in Spain. It also provides hexbin maps and other
+complementary geometries, such as the demarcation lines around the Canary
 Islands.
 
-**mapSpain** provides access to map tiles from Spain's public institutions,
-which can be represented on static maps via `mapSpain::esp_get_tiles()` or on an
-**R** [**leaflet**](https://rstudio.github.io/leaflet/) map using
+**mapSpain** provides access to map tiles from Spain's public institutions.
+Tiles can be represented on static maps with `mapSpain::esp_get_tiles()` or on
+an R [**leaflet**](https://rstudio.github.io/leaflet/) map using
 `mapSpain::addProviderEspTiles()`.
 
 **mapSpain** also includes a dictionary that translates province and region
@@ -55,8 +55,7 @@ statistical agency) coding system.
 
 ## Caching
 
-**mapSpain** provides dataset and tile caching capabilities. Set a cache
-directory with:
+**mapSpain** provides dataset and tile caching. Set a cache directory with:
 
 ```{r}
 #| eval: false
@@ -64,13 +63,12 @@ esp_set_cache_dir("./path/to/location")
 ```
 
 **mapSpain** relies on [**giscoR**](https://ropengov.github.io/giscoR/) for
-downloading certain files, and both packages are well synchronized. Setting the
-same caching directory for both packages will speed up data loading in your
-session.
+downloading some files, and both packages can share cache settings. Using the
+same cache directory for both packages speeds up data loading in your session.
 
 ## Basic example
 
-These examples show what **mapSpain** can do:
+These examples show key **mapSpain** workflows:
 
 ```{r}
 #| label: basic
@@ -154,14 +152,14 @@ library(dplyr)
 census <- mapSpain::pobmun25 |>
   select(-name)
 
-# Extract CCAA from the base dataset.
+# Extract Autonomous Community codes from the base dataset.
 codelist <- mapSpain::esp_codelist |>
   select(cpro, codauto) |>
   distinct()
 
 census_ccaa <- census |>
   left_join(codelist) |>
-  # Summarize by CCAA.
+  # Summarize by Autonomous Community.
   group_by(codauto) |>
   summarise(pob25 = sum(pob25), men = sum(men), women = sum(women)) |>
   mutate(
@@ -219,7 +217,7 @@ pop <- mapSpain::pobmun25 |>
 
 munic <- esp_get_munic_siane(rawcols = TRUE) |>
   # Get area in km2 from SIANE municipalities.
-  # This variable is already in the shapefile.
+  # This variable is already available in the SIANE data.
   mutate(area_km2 = st_area_sh * 10000)
 
 munic_pop <- munic |>
@@ -257,9 +255,9 @@ ggplot(munic_pop) +
 
 ## mapSpain and giscoR
 
-If you need to plot Spain alongside other countries, consider using the
+If you need to plot Spain alongside other countries, use the
 [**giscoR**](https://ropengov.github.io/giscoR/) package, which is installed as
-a dependency with **mapSpain**. Here is a basic example:
+a dependency of **mapSpain**. Here is a basic example:
 
 ```{r}
 #| label: giscoR
@@ -307,13 +305,13 @@ ggplot(all_countries) +
 
 ## Working with tiles
 
-**mapSpain** provides a powerful interface for working with imagery. It can
-download static images as `.png` or `.jpeg` (depending on the Web Map Service)
-and use them alongside your shapefiles.
+**mapSpain** provides an interface for working with imagery. It can download
+static images as `.png` or `.jpeg`, depending on the Web Map Service, and use
+them alongside your `sf` objects.
 
-**mapSpain** also includes a plugin for the **R**
-[**leaflet**](https://rstudio.github.io/leaflet/) package, which allows you to
-include several basemaps on your interactive maps.
+**mapSpain** also includes a plugin for the
+[**leaflet**](https://rstudio.github.io/leaflet/) R package, which allows you to
+add several basemaps to interactive maps.
 
 The services are implemented with the
 [leaflet-providersESP](https://dieghernan.github.io/leaflet-providersESP/)


### PR DESCRIPTION
## Summary

- Refactored internal helpers for downloading and reading geospatial files, SIANE file handling, EPSG validation, region-code filtering, municipal metadata enrichment, empty-result messages and Canary Islands displacement.
- Consolidated repeated CCAA, province and municipality metadata handling across GISCO, SIANE, simplified and gridmap getters.
- Moved test-only access skips into test helpers and adjusted package metadata so `testthat` remains a suggested dependency.

## AI Assistance

This internal refactor was developed with AI assistance and reviewed through focused package checks. The public API is intended to remain unchanged.

## Validation

- `devtools::load_all()`
- `lintr::lint_package()`
