### PR TITLE
Support MAPSPAIN_TIMEOUT environment variable

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # mapSpain (development version)
 
+- Query timeout can now also be controlled with the `MAPSPAIN_TIMEOUT`
+  environment variable.
 - `?esp_tiles_providers`: Updated all WMS providers to use
   `service=WMS&version=1.3.0`.
 

--- a/R/esp-check-access.R
+++ b/R/esp-check-access.R
@@ -24,13 +24,13 @@ esp_check_access <- function() {
 
   url <- api_entry_for_checks()
   req <- httr2::request(url)
-  req <- httr2::req_timeout(req, getOption("mapspain_timeout", 300L))
+  req <- httr2::req_timeout(req, esp_timeout())
   req <- httr2::req_url_path_append(req, "dist/se89_3_admin_ccaa_a_y.gpkg")
   req <- httr2::req_error(req, is_error = function(x) {
     FALSE
   })
   req <- httr2::req_method(req, "HEAD")
-  resp <- httr2::req_perform(req)
+  resp <- esp_req_perform(req)
   if (httr2::resp_is_error(resp)) {
     FALSE
   } else {

--- a/R/utils-url.R
+++ b/R/utils-url.R
@@ -47,7 +47,7 @@ download_url <- function(
   make_msg("info", verbose, msg)
 
   req <- httr2::request(url)
-  req <- httr2::req_timeout(req, getOption("mapspain_timeout", 300L))
+  req <- httr2::req_timeout(req, esp_timeout())
   req <- httr2::req_error(req, is_error = function(x) {
     FALSE
   })
@@ -75,7 +75,7 @@ download_url <- function(
 
   # Use HEAD to check whether the download is large enough to warn about.
   get_header <- httr2::req_method(req, "HEAD")
-  getsize <- httr2::req_perform(get_header)
+  getsize <- esp_req_perform(get_header)
 
   size_dwn <- as.numeric(httr2::resp_header(getsize, "content-length", 0))
   class(size_dwn) <- class(object.size("a"))
@@ -97,7 +97,7 @@ download_url <- function(
     file_local <- tempfile(fileext = ".txt")
   }
 
-  resp <- httr2::req_perform(req, path = file_local)
+  resp <- esp_req_perform(req, path = file_local)
 
   if (httr2::resp_is_error(resp)) {
     unlink(file_local, force = TRUE)
@@ -134,7 +134,7 @@ for_import_jsonlite <- function() {
   # Read JSON from the package website.
   url <- "https://ropenspain.github.io/mapSpain/search.json"
   res <- httr2::request(url)
-  resp <- httr2::req_perform(res)
+  resp <- esp_req_perform(res)
   txt <- httr2::resp_body_string(resp)
   local <- jsonlite::parse_json(txt)
 
@@ -153,6 +153,17 @@ is_online_fun <- function(...) {
   httr2::is_online()
 }
 
+#' Wrap [httr2::req_perform()] for testing
+#'
+#' @param ... Passed to [httr2::req_perform()].
+#'
+#' @noRd
+# nocov start
+esp_req_perform <- function(...) {
+  httr2::req_perform(...)
+}
+# nocov end
+
 #' Wrap HTTP 404 checks for testing
 #'
 #' @param ... Ignored.
@@ -160,4 +171,37 @@ is_online_fun <- function(...) {
 #' @noRd
 is_404 <- function(...) {
   FALSE
+}
+
+#' Get an HTTP configuration value from options or environment variables
+#'
+#' @param option Character. Name of the R option.
+#' @param envvar Character. Name of the environment variable.
+#' @param default Numeric. Default value to use when neither setting is valid.
+#'
+#' @noRd
+esp_http_config <- function(option, envvar, default) {
+  opt <- getOption(option, NULL)
+  if (!is.null(opt)) {
+    return(opt)
+  }
+
+  env <- Sys.getenv(envvar, unset = NA_character_)
+  if (is.na(env) || identical(env, "")) {
+    return(default)
+  }
+
+  env_num <- suppressWarnings(as.numeric(env))
+  if (is.na(env_num)) {
+    return(default)
+  }
+
+  env_num
+}
+
+#' Get the timeout setting for mapSpain HTTP requests
+#'
+#' @noRd
+esp_timeout <- function() {
+  esp_http_config("mapspain_timeout", "MAPSPAIN_TIMEOUT", 300L)
 }

--- a/tests/testthat/test-utils-url.R
+++ b/tests/testthat/test-utils-url.R
@@ -1,3 +1,55 @@
+test_that("HTTP timeout can be controlled with an environment variable", {
+  withr::local_options(list(mapspain_timeout = NULL))
+  withr::local_envvar(c(MAPSPAIN_TIMEOUT = "600"))
+
+  expect_equal(esp_timeout(), 600)
+
+  withr::local_envvar(c(MAPSPAIN_TIMEOUT = NA))
+  expect_equal(esp_timeout(), 300L)
+
+  withr::local_envvar(c(MAPSPAIN_TIMEOUT = "invalid"))
+  expect_equal(esp_timeout(), 300L)
+})
+
+test_that("HTTP timeout option takes precedence over environment variable", {
+  withr::local_options(list(mapspain_timeout = 30))
+  withr::local_envvar(c(MAPSPAIN_TIMEOUT = "600"))
+
+  expect_equal(esp_timeout(), 30)
+})
+
+test_that("HTTP timeout environment variable is used in requests", {
+  withr::local_options(list(mapspain_timeout = NULL))
+  withr::local_envvar(c(MAPSPAIN_TIMEOUT = "600"))
+
+  seen <- list()
+  local_mocked_bindings(
+    is_online_fun = function(...) TRUE,
+    esp_req_perform = function(req, path = NULL, ...) {
+      seen[[length(seen) + 1]] <<- req$options
+      if (is.null(path)) {
+        return(httr2::response(
+          status_code = 200,
+          headers = list("content-length" = "2")
+        ))
+      }
+
+      writeLines("ok", path)
+      httr2::response(status_code = 200)
+    }
+  )
+
+  cdir <- withr::local_tempdir(pattern = "testthat_envvar")
+  out <- download_url(
+    "https://example.com/envvar.txt",
+    cache_dir = cdir,
+    verbose = FALSE
+  )
+
+  expect_type(out, "character")
+  expect_equal(seen[[1]]$timeout_ms, 600000)
+})
+
 test_that("Test offline", {
   skip_on_cran()
   skip_if_siane_offline()


### PR DESCRIPTION
## Summary

- Add an internal HTTP configuration helper that reads `options()` first and falls back to environment variables.
- Allow `MAPSPAIN_TIMEOUT` to control the existing `mapspain_timeout` setting when the R option is unset.
- Cover environment variable behavior with focused tests and update `NEWS.md`.

## Validation

- `air format .`
- `Rscript -e "devtools::load_all(); devtools::test(filter = '^utils-url|^esp-check-access')"`
- `Rscript -e "devtools::load_all(); devtools::test_coverage_active_file('R/utils-url.R')"`
- `Rscript -e "devtools::load_all(); devtools::lint()"`
- `jarl check .`